### PR TITLE
Release 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [1.0.3](https://github.com/apollographql/protobuf.js/releases/tag/1.0.3)
+
+## Other
+[:hash:](https://github.com/apollographql/protobuf.js/commit/886019a71fe6f01e9ff3d826f402c4ebed38f38f) Version bump for release<br />
+[:hash:](https://github.com/apollographql/protobuf.js/commit/d13506a71f0634ea7a89a57e0102460b9bb438fb) Remove duplicated Long types in index.d.ts<br />
+
 # [1.0.2](https://github.com/apollographql/protobuf.js/releases/tag/1.0.2)
 
 ## Other

--- a/cli/package.standalone.json
+++ b/cli/package.standalone.json
@@ -15,7 +15,7 @@
     "pbts": "bin/pbts"
   },
   "peerDependencies": {
-    "@apollo/protobufjs": "~1.0.2"
+    "@apollo/protobufjs": "~1.0.3"
   },
   "dependencies": {
     "chalk": "^1.1.3",

--- a/dist/light/protobuf.js
+++ b/dist/light/protobuf.js
@@ -1,6 +1,6 @@
 /*!
- * protobuf.js v1.0.2 (c) 2016, daniel wirtz
- * compiled thu, 21 nov 2019 00:12:17 utc
+ * protobuf.js v1.0.3 (c) 2016, daniel wirtz
+ * compiled thu, 21 nov 2019 00:36:05 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/light/protobuf.min.js
+++ b/dist/light/protobuf.min.js
@@ -1,6 +1,6 @@
 /*!
- * protobuf.js v1.0.2 (c) 2016, daniel wirtz
- * compiled thu, 21 nov 2019 00:12:18 utc
+ * protobuf.js v1.0.3 (c) 2016, daniel wirtz
+ * compiled thu, 21 nov 2019 00:36:06 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/minimal/protobuf.js
+++ b/dist/minimal/protobuf.js
@@ -1,6 +1,6 @@
 /*!
- * protobuf.js v1.0.2 (c) 2016, daniel wirtz
- * compiled thu, 21 nov 2019 00:12:17 utc
+ * protobuf.js v1.0.3 (c) 2016, daniel wirtz
+ * compiled thu, 21 nov 2019 00:36:05 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/minimal/protobuf.min.js
+++ b/dist/minimal/protobuf.min.js
@@ -1,6 +1,6 @@
 /*!
- * protobuf.js v1.0.2 (c) 2016, daniel wirtz
- * compiled thu, 21 nov 2019 00:12:18 utc
+ * protobuf.js v1.0.3 (c) 2016, daniel wirtz
+ * compiled thu, 21 nov 2019 00:36:06 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/protobuf.js
+++ b/dist/protobuf.js
@@ -1,6 +1,6 @@
 /*!
- * protobuf.js v1.0.2 (c) 2016, daniel wirtz
- * compiled thu, 21 nov 2019 00:12:17 utc
+ * protobuf.js v1.0.3 (c) 2016, daniel wirtz
+ * compiled thu, 21 nov 2019 00:36:05 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/protobuf.min.js
+++ b/dist/protobuf.min.js
@@ -1,6 +1,6 @@
 /*!
- * protobuf.js v1.0.2 (c) 2016, daniel wirtz
- * compiled thu, 21 nov 2019 00:12:18 utc
+ * protobuf.js v1.0.3 (c) 2016, daniel wirtz
+ * compiled thu, 21 nov 2019 00:36:06 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/protobufjs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/protobufjs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "versionScheme": "~",
   "description": "Protocol Buffers for JavaScript (& TypeScript).",
   "author": "Daniel Wirtz <dcode+protobufjs@dcode.io>",


### PR DESCRIPTION
Version bump to `v1.0.3`

Per @Enrico2 's steps:

> 1. update code and version bump
> 2. npm install
> 3. commit
> 4. npm run release <-- this should update the Changelog in a way that makes sense, this is why we commit in step 3.
> 5. commit again to commit changelog and dist changes.
> 6. git tag 1.0.3 && git push && git push --tags <-- or whatever the next version is

TODO: merge and `npm publish`