### PR TITLE
Map field TypeScript types shouldn't imply all keys exist

### DIFF
--- a/bench/data/static_pbjs.js
+++ b/bench/data/static_pbjs.js
@@ -24,13 +24,13 @@ $root.Test = (function() {
     Test.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.string != null && message.hasOwnProperty("string"))
+        if (message.string != null && Object.hasOwnProperty.call(message, "string"))
             writer.uint32(10).string(message.string);
-        if (message.uint32 != null && message.hasOwnProperty("uint32"))
+        if (message.uint32 != null && Object.hasOwnProperty.call(message, "uint32"))
             writer.uint32(16).uint32(message.uint32);
-        if (message.inner != null && message.hasOwnProperty("inner"))
+        if (message.inner != null && Object.hasOwnProperty.call(message, "inner"))
             $root.Test.Inner.encode(message.inner, writer.uint32(26).fork()).ldelim();
-        if (message.float != null && message.hasOwnProperty("float"))
+        if (message.float != null && Object.hasOwnProperty.call(message, "float"))
             writer.uint32(37).float(message.float);
         return writer;
     };
@@ -78,11 +78,11 @@ $root.Test = (function() {
         Inner.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
-            if (message.int32 != null && message.hasOwnProperty("int32"))
+            if (message.int32 != null && Object.hasOwnProperty.call(message, "int32"))
                 writer.uint32(8).int32(message.int32);
-            if (message.innerInner != null && message.hasOwnProperty("innerInner"))
+            if (message.innerInner != null && Object.hasOwnProperty.call(message, "innerInner"))
                 $root.Test.Inner.InnerInner.encode(message.innerInner, writer.uint32(18).fork()).ldelim();
-            if (message.outer != null && message.hasOwnProperty("outer"))
+            if (message.outer != null && Object.hasOwnProperty.call(message, "outer"))
                 $root.Outer.encode(message.outer, writer.uint32(26).fork()).ldelim();
             return writer;
         };
@@ -127,11 +127,11 @@ $root.Test = (function() {
             InnerInner.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.long != null && message.hasOwnProperty("long"))
+                if (message.long != null && Object.hasOwnProperty.call(message, "long"))
                     writer.uint32(8).int64(message.long);
-                if (message["enum"] != null && message.hasOwnProperty("enum"))
+                if (message["enum"] != null && Object.hasOwnProperty.call(message, "enum"))
                     writer.uint32(16).int32(message["enum"]);
-                if (message.sint32 != null && message.hasOwnProperty("sint32"))
+                if (message.sint32 != null && Object.hasOwnProperty.call(message, "sint32"))
                     writer.uint32(24).sint32(message.sint32);
                 return writer;
             };
@@ -201,7 +201,7 @@ $root.Outer = (function() {
                 writer.bool(message.bool[i]);
             writer.ldelim();
         }
-        if (message.double != null && message.hasOwnProperty("double"))
+        if (message.double != null && Object.hasOwnProperty.call(message, "double"))
             writer.uint32(17).double(message.double);
         return writer;
     };

--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -286,9 +286,9 @@ function getTypeOf(element) {
         return $1 + "[]";
     });
 
-    // Replace Object.<string,number> with { [k: string]: number }
+    // Replace Object.<string,number> with { [k: string]: number | undefined }
     name = replaceRecursive(name, /\bObject\.?<([^,]*), *([^>]*)>/gi, function($0, $1, $2) {
-        return "{ [k: " + $1 + "]: " + $2 + " }";
+        return "{ [k: " + $1 + "]: " + $2 + " | undefined }";
     });
 
     // Replace functions (there are no signatures) with Function

--- a/dist/light/protobuf.js
+++ b/dist/light/protobuf.js
@@ -1,6 +1,6 @@
 /*!
  * protobuf.js v1.0.4 (c) 2016, daniel wirtz
- * compiled thu, 21 may 2020 17:44:20 utc
+ * compiled thu, 13 aug 2020 23:19:10 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/light/protobuf.min.js
+++ b/dist/light/protobuf.min.js
@@ -1,6 +1,6 @@
 /*!
  * protobuf.js v1.0.4 (c) 2016, daniel wirtz
- * compiled thu, 21 may 2020 17:44:21 utc
+ * compiled thu, 13 aug 2020 23:19:10 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/minimal/protobuf.js
+++ b/dist/minimal/protobuf.js
@@ -1,6 +1,6 @@
 /*!
  * protobuf.js v1.0.4 (c) 2016, daniel wirtz
- * compiled thu, 21 may 2020 17:44:20 utc
+ * compiled thu, 13 aug 2020 23:19:10 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/minimal/protobuf.min.js
+++ b/dist/minimal/protobuf.min.js
@@ -1,6 +1,6 @@
 /*!
  * protobuf.js v1.0.4 (c) 2016, daniel wirtz
- * compiled thu, 21 may 2020 17:44:20 utc
+ * compiled thu, 13 aug 2020 23:19:10 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/protobuf.js
+++ b/dist/protobuf.js
@@ -1,6 +1,6 @@
 /*!
  * protobuf.js v1.0.4 (c) 2016, daniel wirtz
- * compiled thu, 21 may 2020 17:44:20 utc
+ * compiled thu, 13 aug 2020 23:19:10 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/protobuf.min.js
+++ b/dist/protobuf.min.js
@@ -1,6 +1,6 @@
 /*!
  * protobuf.js v1.0.4 (c) 2016, daniel wirtz
- * compiled thu, 21 may 2020 17:44:21 utc
+ * compiled thu, 13 aug 2020 23:19:10 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/ext/descriptor/index.d.ts
+++ b/ext/descriptor/index.d.ts
@@ -1,3 +1,5 @@
+import * as Long from "long";
+
 import * as $protobuf from "../..";
 export const FileDescriptorSet: $protobuf.Type;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export as namespace protobuf;
  * @param name Short name as in `google/protobuf/[name].proto` or full file name
  * @param json JSON definition within `google.protobuf` if a short name, otherwise the file's root definition
  */
-export function common(name: string, json: { [k: string]: any }): void;
+export function common(name: string, json: { [k: string]: any | undefined }): void;
 
 export namespace common {
 
@@ -38,7 +38,7 @@ export namespace common {
 
     /** Properties of a google.protobuf.Struct message. */
     interface IStruct {
-        fields?: { [k: string]: IValue };
+        fields?: { [k: string]: IValue | undefined };
     }
 
     /** Properties of a google.protobuf.Value message. */
@@ -163,19 +163,19 @@ export class Enum extends ReflectionObject {
      * @param [comment] The comment for this enum
      * @param [comments] The value comments for this enum
      */
-    constructor(name: string, values?: { [k: string]: number }, options?: { [k: string]: any }, comment?: string, comments?: { [k: string]: string });
+    constructor(name: string, values?: { [k: string]: number | undefined }, options?: { [k: string]: any | undefined }, comment?: string, comments?: { [k: string]: string | undefined });
 
     /** Enum values by id. */
-    public valuesById: { [k: number]: string };
+    public valuesById: { [k: number]: string | undefined };
 
     /** Enum values by name. */
-    public values: { [k: string]: number };
+    public values: { [k: string]: number | undefined };
 
     /** Enum comment text. */
     public comment: (string|null);
 
     /** Value comment texts, if any. */
-    public comments: { [k: string]: string };
+    public comments: { [k: string]: string | undefined };
 
     /** Reserved ranges, if any. */
     public reserved: (number[]|string)[];
@@ -235,10 +235,10 @@ export class Enum extends ReflectionObject {
 export interface IEnum {
 
     /** Enum values */
-    values: { [k: string]: number };
+    values: { [k: string]: number | undefined };
 
     /** Enum options */
-    options?: { [k: string]: any };
+    options?: { [k: string]: any | undefined };
 }
 
 /** Reflected message field. */
@@ -253,7 +253,7 @@ export class Field extends FieldBase {
      * @param [extend] Extended type if different from parent
      * @param [options] Declared options
      */
-    constructor(name: string, id: number, type: string, rule?: (string|{ [k: string]: any }), extend?: (string|{ [k: string]: any }), options?: { [k: string]: any });
+    constructor(name: string, id: number, type: string, rule?: (string|{ [k: string]: any | undefined }), extend?: (string|{ [k: string]: any | undefined }), options?: { [k: string]: any | undefined });
 
     /**
      * Constructs a field from a field descriptor.
@@ -300,7 +300,7 @@ export class FieldBase extends ReflectionObject {
      * @param [options] Declared options
      * @param [comment] Comment associated with this field
      */
-    constructor(name: string, id: number, type: string, rule?: (string|{ [k: string]: any }), extend?: (string|{ [k: string]: any }), options?: { [k: string]: any }, comment?: string);
+    constructor(name: string, id: number, type: string, rule?: (string|{ [k: string]: any | undefined }), extend?: (string|{ [k: string]: any | undefined }), options?: { [k: string]: any | undefined }, comment?: string);
 
     /** Field rule, if any. */
     public rule?: string;
@@ -384,7 +384,7 @@ export interface IField {
     id: number;
 
     /** Field options */
-    options?: { [k: string]: any };
+    options?: { [k: string]: any | undefined };
 }
 
 /** Extension field descriptor. */
@@ -462,7 +462,7 @@ export class MapField extends FieldBase {
      * @param [options] Declared options
      * @param [comment] Comment associated with this field
      */
-    constructor(name: string, id: number, keyType: string, type: string, options?: { [k: string]: any }, comment?: string);
+    constructor(name: string, id: number, keyType: string, type: string, options?: { [k: string]: any | undefined }, comment?: string);
 
     /** Key type. */
     public keyType: string;
@@ -530,7 +530,7 @@ export class Message<T extends object = object> {
      * @param [properties] Properties to set
      * @returns Message instance
      */
-    public static create<T extends Message<T>>(this: Constructor<T>, properties?: { [k: string]: any }): Message<T>;
+    public static create<T extends Message<T>>(this: Constructor<T>, properties?: { [k: string]: any | undefined }): Message<T>;
 
     /**
      * Encodes a message of this type.
@@ -538,7 +538,7 @@ export class Message<T extends object = object> {
      * @param [writer] Writer to use
      * @returns Writer
      */
-    public static encode<T extends Message<T>>(this: Constructor<T>, message: (T|{ [k: string]: any }), writer?: Writer): Writer;
+    public static encode<T extends Message<T>>(this: Constructor<T>, message: (T|{ [k: string]: any | undefined }), writer?: Writer): Writer;
 
     /**
      * Encodes a message of this type preceeded by its length as a varint.
@@ -546,7 +546,7 @@ export class Message<T extends object = object> {
      * @param [writer] Writer to use
      * @returns Writer
      */
-    public static encodeDelimited<T extends Message<T>>(this: Constructor<T>, message: (T|{ [k: string]: any }), writer?: Writer): Writer;
+    public static encodeDelimited<T extends Message<T>>(this: Constructor<T>, message: (T|{ [k: string]: any | undefined }), writer?: Writer): Writer;
 
     /**
      * Decodes a message of this type.
@@ -567,14 +567,14 @@ export class Message<T extends object = object> {
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): (string|null);
+    public static verify(message: { [k: string]: any | undefined }): (string|null);
 
     /**
      * Creates a new message of this type from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns Message instance
      */
-    public static fromObject<T extends Message<T>>(this: Constructor<T>, object: { [k: string]: any }): T;
+    public static fromObject<T extends Message<T>>(this: Constructor<T>, object: { [k: string]: any | undefined }): T;
 
     /**
      * Creates a plain object from a message of this type. Also converts values to other types if specified.
@@ -582,13 +582,13 @@ export class Message<T extends object = object> {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject<T extends Message<T>>(this: Constructor<T>, message: T, options?: IConversionOptions): { [k: string]: any };
+    public static toObject<T extends Message<T>>(this: Constructor<T>, message: T, options?: IConversionOptions): { [k: string]: any | undefined };
 
     /**
      * Converts this message to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    public toJSON(): { [k: string]: any | undefined };
 }
 
 /** Reflected service method. */
@@ -605,7 +605,7 @@ export class Method extends ReflectionObject {
      * @param [options] Declared options
      * @param [comment] The comment for this method
      */
-    constructor(name: string, type: (string|undefined), requestType: string, responseType: string, requestStream?: (boolean|{ [k: string]: any }), responseStream?: (boolean|{ [k: string]: any }), options?: { [k: string]: any }, comment?: string);
+    constructor(name: string, type: (string|undefined), requestType: string, responseType: string, requestStream?: (boolean|{ [k: string]: any | undefined }), responseStream?: (boolean|{ [k: string]: any | undefined }), options?: { [k: string]: any | undefined }, comment?: string);
 
     /** Method type. */
     public type: string;
@@ -667,7 +667,7 @@ export interface IMethod {
     responseStream?: boolean;
 
     /** Method options */
-    options?: { [k: string]: any };
+    options?: { [k: string]: any | undefined };
 }
 
 /** Reflected namespace. */
@@ -678,7 +678,7 @@ export class Namespace extends NamespaceBase {
      * @param name Namespace name
      * @param [options] Declared options
      */
-    constructor(name: string, options?: { [k: string]: any });
+    constructor(name: string, options?: { [k: string]: any | undefined });
 
     /**
      * Constructs a namespace from JSON.
@@ -687,7 +687,7 @@ export class Namespace extends NamespaceBase {
      * @returns Created namespace
      * @throws {TypeError} If arguments are invalid
      */
-    public static fromJSON(name: string, json: { [k: string]: any }): Namespace;
+    public static fromJSON(name: string, json: { [k: string]: any | undefined }): Namespace;
 
     /**
      * Converts an array of reflection objects to JSON.
@@ -695,7 +695,7 @@ export class Namespace extends NamespaceBase {
      * @param [toJSONOptions] JSON conversion options
      * @returns JSON object or `undefined` when array is empty
      */
-    public static arrayToJSON(array: ReflectionObject[], toJSONOptions?: IToJSONOptions): ({ [k: string]: any }|undefined);
+    public static arrayToJSON(array: ReflectionObject[], toJSONOptions?: IToJSONOptions): ({ [k: string]: any | undefined }|undefined);
 
     /**
      * Tests if the specified id is reserved.
@@ -718,7 +718,7 @@ export class Namespace extends NamespaceBase {
 export abstract class NamespaceBase extends ReflectionObject {
 
     /** Nested objects by name. */
-    public nested?: { [k: string]: ReflectionObject };
+    public nested?: { [k: string]: ReflectionObject | undefined };
 
     /** Nested objects of this namespace as an array for iteration. */
     public readonly nestedArray: ReflectionObject[];
@@ -735,7 +735,7 @@ export abstract class NamespaceBase extends ReflectionObject {
      * @param nestedJson Any nested object descriptors
      * @returns `this`
      */
-    public addJSON(nestedJson: { [k: string]: AnyNestedObject }): Namespace;
+    public addJSON(nestedJson: { [k: string]: AnyNestedObject | undefined }): Namespace;
 
     /**
      * Gets the nested object of the specified name.
@@ -751,7 +751,7 @@ export abstract class NamespaceBase extends ReflectionObject {
      * @returns Enum values
      * @throws {Error} If there is no such enum
      */
-    public getEnum(name: string): { [k: string]: number };
+    public getEnum(name: string): { [k: string]: number | undefined };
 
     /**
      * Adds a nested object to this namespace.
@@ -843,10 +843,10 @@ export abstract class NamespaceBase extends ReflectionObject {
 export interface INamespace {
 
     /** Namespace options */
-    options?: { [k: string]: any };
+    options?: { [k: string]: any | undefined };
 
     /** Nested object descriptors */
-    nested?: { [k: string]: AnyNestedObject };
+    nested?: { [k: string]: AnyNestedObject | undefined };
 }
 
 /** Any extension field descriptor. */
@@ -859,7 +859,7 @@ type AnyNestedObject = (IEnum|IType|IService|AnyExtensionField|INamespace);
 export abstract class ReflectionObject {
 
     /** Options. */
-    public options?: { [k: string]: any };
+    public options?: { [k: string]: any | undefined };
 
     /** Unique name within its namespace. */
     public name: string;
@@ -886,7 +886,7 @@ export abstract class ReflectionObject {
      * Converts this reflection object to its descriptor representation.
      * @returns Descriptor
      */
-    public toJSON(): { [k: string]: any };
+    public toJSON(): { [k: string]: any | undefined };
 
     /**
      * Called when this object is added to a parent.
@@ -928,7 +928,7 @@ export abstract class ReflectionObject {
      * @param [ifNotSet] Sets an option only if it isn't currently set
      * @returns `this`
      */
-    public setOptions(options: { [k: string]: any }, ifNotSet?: boolean): ReflectionObject;
+    public setOptions(options: { [k: string]: any | undefined }, ifNotSet?: boolean): ReflectionObject;
 
     /**
      * Converts this instance to its string representation.
@@ -947,7 +947,7 @@ export class OneOf extends ReflectionObject {
      * @param [options] Declared options
      * @param [comment] Comment associated with this field
      */
-    constructor(name: string, fieldNames?: (string[]|{ [k: string]: any }), options?: { [k: string]: any }, comment?: string);
+    constructor(name: string, fieldNames?: (string[]|{ [k: string]: any | undefined }), options?: { [k: string]: any | undefined }, comment?: string);
 
     /** Field names that belong to this oneof. */
     public oneof: string[];
@@ -1003,7 +1003,7 @@ export interface IOneOf {
     oneof: string[];
 
     /** Oneof options */
-    options?: { [k: string]: any };
+    options?: { [k: string]: any | undefined };
 }
 
 /**
@@ -1220,7 +1220,7 @@ export class Root extends NamespaceBase {
      * Constructs a new root namespace instance.
      * @param [options] Top level options
      */
-    constructor(options?: { [k: string]: any });
+    constructor(options?: { [k: string]: any | undefined });
 
     /** Deferred extension fields. */
     public deferred: Field[];
@@ -1283,7 +1283,7 @@ export class Root extends NamespaceBase {
  * This is where pbjs stores generated structures (the option `-r, --root` specifies a name).
  * Can also be used manually to make roots available accross modules.
  */
-export let roots: { [k: string]: Root };
+export let roots: { [k: string]: Root | undefined };
 
 /** Streaming RPC helpers. */
 export namespace rpc {
@@ -1368,10 +1368,10 @@ export class Service extends NamespaceBase {
      * @param [options] Service options
      * @throws {TypeError} If arguments are invalid
      */
-    constructor(name: string, options?: { [k: string]: any });
+    constructor(name: string, options?: { [k: string]: any | undefined });
 
     /** Service methods. */
-    public methods: { [k: string]: Method };
+    public methods: { [k: string]: Method | undefined };
 
     /**
      * Constructs a service from a service descriptor.
@@ -1406,7 +1406,7 @@ export class Service extends NamespaceBase {
 export interface IService extends INamespace {
 
     /** Method descriptors */
-    methods: { [k: string]: IMethod };
+    methods: { [k: string]: IMethod | undefined };
 }
 
 /**
@@ -1491,13 +1491,13 @@ export class Type extends NamespaceBase {
      * @param name Message name
      * @param [options] Declared options
      */
-    constructor(name: string, options?: { [k: string]: any });
+    constructor(name: string, options?: { [k: string]: any | undefined });
 
     /** Message fields. */
-    public fields: { [k: string]: Field };
+    public fields: { [k: string]: Field | undefined };
 
     /** Oneofs declared within this namespace, if any. */
-    public oneofs: { [k: string]: OneOf };
+    public oneofs: { [k: string]: OneOf | undefined };
 
     /** Extension ranges, if any. */
     public extensions: number[][];
@@ -1506,7 +1506,7 @@ export class Type extends NamespaceBase {
     public reserved: (number[]|string)[];
 
     /** Message fields by id. */
-    public readonly fieldsById: { [k: number]: Field };
+    public readonly fieldsById: { [k: number]: Field | undefined };
 
     /** Fields of this message as an array for iteration. */
     public readonly fieldsArray: Field[];
@@ -1579,7 +1579,7 @@ export class Type extends NamespaceBase {
      * @param [properties] Properties to set
      * @returns Message instance
      */
-    public create(properties?: { [k: string]: any }): Message<{}>;
+    public create(properties?: { [k: string]: any | undefined }): Message<{}>;
 
     /**
      * Sets up {@link Type#encode|encode}, {@link Type#decode|decode} and {@link Type#verify|verify}.
@@ -1593,7 +1593,7 @@ export class Type extends NamespaceBase {
      * @param [writer] Writer to encode to
      * @returns writer
      */
-    public encode(message: (Message<{}>|{ [k: string]: any }), writer?: Writer): Writer;
+    public encode(message: (Message<{}>|{ [k: string]: any | undefined }), writer?: Writer): Writer;
 
     /**
      * Encodes a message of this type preceeded by its byte length as a varint. Does not implicitly {@link Type#verify|verify} messages.
@@ -1601,7 +1601,7 @@ export class Type extends NamespaceBase {
      * @param [writer] Writer to encode to
      * @returns writer
      */
-    public encodeDelimited(message: (Message<{}>|{ [k: string]: any }), writer?: Writer): Writer;
+    public encodeDelimited(message: (Message<{}>|{ [k: string]: any | undefined }), writer?: Writer): Writer;
 
     /**
      * Decodes a message of this type.
@@ -1627,14 +1627,14 @@ export class Type extends NamespaceBase {
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public verify(message: { [k: string]: any }): (null|string);
+    public verify(message: { [k: string]: any | undefined }): (null|string);
 
     /**
      * Creates a new message of this type from a plain object. Also converts values to their respective internal types.
      * @param object Plain object to convert
      * @returns Message instance
      */
-    public fromObject(object: { [k: string]: any }): Message<{}>;
+    public fromObject(object: { [k: string]: any | undefined }): Message<{}>;
 
     /**
      * Creates a plain object from a message of this type. Also converts values to other types if specified.
@@ -1642,7 +1642,7 @@ export class Type extends NamespaceBase {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public toObject(message: Message<{}>, options?: IConversionOptions): { [k: string]: any };
+    public toObject(message: Message<{}>, options?: IConversionOptions): { [k: string]: any | undefined };
 
     /**
      * Type decorator (TypeScript).
@@ -1656,10 +1656,10 @@ export class Type extends NamespaceBase {
 export interface IType extends INamespace {
 
     /** Oneof descriptors */
-    oneofs?: { [k: string]: IOneOf };
+    oneofs?: { [k: string]: IOneOf | undefined };
 
     /** Field descriptors */
-    fields: { [k: string]: IField };
+    fields: { [k: string]: IField | undefined };
 
     /** Extension ranges */
     extensions?: number[][];
@@ -2013,7 +2013,7 @@ export namespace util {
      * @param [ifNotSet=false] Merges only if the key is not already set
      * @returns Destination object
      */
-    function merge(dst: { [k: string]: any }, src: { [k: string]: any }, ifNotSet?: boolean): { [k: string]: any };
+    function merge(dst: { [k: string]: any | undefined }, src: { [k: string]: any | undefined }, ifNotSet?: boolean): { [k: string]: any | undefined };
 
     /**
      * Converts the first character of a string to lower case.
@@ -2037,7 +2037,7 @@ export namespace util {
          * @param message Error message
          * @param [properties] Additional properties
          */
-        constructor(message: string, properties?: { [k: string]: any });
+        constructor(message: string, properties?: { [k: string]: any | undefined });
 
         /** So far decoded message instance. */
         public instance: Message<T>;
@@ -2075,21 +2075,21 @@ export namespace util {
     let toJSONOptions: IConversionOptions;
 
     /** Node's fs module if available. */
-    let fs: { [k: string]: any };
+    let fs: { [k: string]: any | undefined };
 
     /**
      * Converts an object's values to an array.
      * @param object Object to convert
      * @returns Converted array
      */
-    function toArray(object: { [k: string]: any }): any[];
+    function toArray(object: { [k: string]: any | undefined }): any[];
 
     /**
      * Converts an array of keys immediately followed by their respective value to an object, omitting undefined values.
      * @param array Array to convert
      * @returns Converted object
      */
-    function toObject(array: any[]): { [k: string]: any };
+    function toObject(array: any[]): { [k: string]: any | undefined };
 
     /**
      * Tests whether the specified name is a reserved word in JS.
@@ -2416,14 +2416,14 @@ export namespace util {
 export function verifier(mtype: Type): Codegen;
 
 /** Wrappers for common types. */
-export const wrappers: { [k: string]: IWrapper };
+export const wrappers: { [k: string]: IWrapper | undefined };
 
 /**
  * From object converter part of an {@link IWrapper}.
  * @param object Plain object
  * @returns Message instance
  */
-type WrapperFromObjectConverter = (this: Type, object: { [k: string]: any }) => Message<{}>;
+type WrapperFromObjectConverter = (this: Type, object: { [k: string]: any | undefined }) => Message<{}>;
 
 /**
  * To object converter part of an {@link IWrapper}.
@@ -2431,7 +2431,7 @@ type WrapperFromObjectConverter = (this: Type, object: { [k: string]: any }) => 
  * @param [options] Conversion options
  * @returns Plain object
  */
-type WrapperToObjectConverter = (this: Type, message: Message<{}>, options?: IConversionOptions) => { [k: string]: any };
+type WrapperToObjectConverter = (this: Type, message: Message<{}>, options?: IConversionOptions) => { [k: string]: any | undefined };
 
 /** Common type wrapper part of {@link wrappers}. */
 export interface IWrapper {
@@ -2644,7 +2644,7 @@ type asPromiseCallback = (error: (Error|null), ...params: any[]) => void;
  * @returns Itself or the generated function if finished
  * @throws {Error} If format parameter counts do not match
  */
-type Codegen = (formatStringOrScope?: (string|{ [k: string]: any }), ...formatParams: any[]) => (Codegen|Function);
+type Codegen = (formatStringOrScope?: (string|{ [k: string]: any | undefined }), ...formatParams: any[]) => (Codegen|Function);
 
 /**
  * Event listener as used by {@link util.EventEmitter}.

--- a/tests/data/comments.d.ts
+++ b/tests/data/comments.d.ts
@@ -1,3 +1,5 @@
+import * as Long from "long";
+
 import * as $protobuf from "../..";
 export interface ITest1 {
     field1?: (string|null);
@@ -15,10 +17,10 @@ export class Test1 implements ITest1 {
     public static encodeDelimited(message: ITest1, writer?: $protobuf.Writer): $protobuf.Writer;
     public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Test1;
     public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Test1;
-    public static verify(message: { [k: string]: any }): (string|null);
-    public static fromObject(object: { [k: string]: any }): Test1;
-    public static toObject(message: Test1, options?: $protobuf.IConversionOptions): { [k: string]: any };
-    public toJSON(): { [k: string]: any };
+    public static verify(message: { [k: string]: any | undefined }): (string|null);
+    public static fromObject(object: { [k: string]: any | undefined }): Test1;
+    public static toObject(message: Test1, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+    public toJSON(): { [k: string]: any | undefined };
 }
 
 export interface ITest2 {
@@ -31,15 +33,8 @@ export class Test2 implements ITest2 {
     public static encodeDelimited(message: ITest2, writer?: $protobuf.Writer): $protobuf.Writer;
     public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Test2;
     public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Test2;
-    public static verify(message: { [k: string]: any }): (string|null);
-    public static fromObject(object: { [k: string]: any }): Test2;
-    public static toObject(message: Test2, options?: $protobuf.IConversionOptions): { [k: string]: any };
-    public toJSON(): { [k: string]: any };
-}
-
-export enum Test3 {
-    ONE = 1,
-    TWO = 2,
-    THREE = 3,
-    FOUR = 4
+    public static verify(message: { [k: string]: any | undefined }): (string|null);
+    public static fromObject(object: { [k: string]: any | undefined }): Test2;
+    public static toObject(message: Test2, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+    public toJSON(): { [k: string]: any | undefined };
 }

--- a/tests/data/comments.js
+++ b/tests/data/comments.js
@@ -86,11 +86,11 @@ $root.Test1 = (function() {
     Test1.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.field1 != null && message.hasOwnProperty("field1"))
+        if (message.field1 != null && Object.hasOwnProperty.call(message, "field1"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.field1);
-        if (message.field2 != null && message.hasOwnProperty("field2"))
+        if (message.field2 != null && Object.hasOwnProperty.call(message, "field2"))
             writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.field2);
-        if (message.field3 != null && message.hasOwnProperty("field3"))
+        if (message.field3 != null && Object.hasOwnProperty.call(message, "field3"))
             writer.uint32(/* id 3, wireType 0 =*/24).bool(message.field3);
         return writer;
     };

--- a/tests/data/convert.d.ts
+++ b/tests/data/convert.d.ts
@@ -1,3 +1,5 @@
+import * as Long from "long";
+
 import * as $protobuf from "../..";
 export interface IMessage {
     stringVal?: (string|null);
@@ -8,7 +10,7 @@ export interface IMessage {
     bytesRepeated?: (Uint8Array[]|null);
     enumVal?: (Message.SomeEnum|null);
     enumRepeated?: (Message.SomeEnum[]|null);
-    int64Map?: ({ [k: string]: (number|Long) }|null);
+    int64Map?: ({ [k: string]: (number|Long) | undefined }|null);
 }
 
 export class Message implements IMessage {
@@ -21,16 +23,16 @@ export class Message implements IMessage {
     public bytesRepeated: Uint8Array[];
     public enumVal: Message.SomeEnum;
     public enumRepeated: Message.SomeEnum[];
-    public int64Map: { [k: string]: (number|Long) };
+    public int64Map: { [k: string]: (number|Long) | undefined };
     public static create(properties?: IMessage): Message;
     public static encode(message: IMessage, writer?: $protobuf.Writer): $protobuf.Writer;
     public static encodeDelimited(message: IMessage, writer?: $protobuf.Writer): $protobuf.Writer;
     public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Message;
     public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Message;
-    public static verify(message: { [k: string]: any }): (string|null);
-    public static fromObject(object: { [k: string]: any }): Message;
-    public static toObject(message: Message, options?: $protobuf.IConversionOptions): { [k: string]: any };
-    public toJSON(): { [k: string]: any };
+    public static verify(message: { [k: string]: any | undefined }): (string|null);
+    public static fromObject(object: { [k: string]: any | undefined }): Message;
+    public static toObject(message: Message, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+    public toJSON(): { [k: string]: any | undefined };
 }
 
 export namespace Message {

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -142,12 +142,12 @@ $root.Message = (function() {
     Message.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.stringVal != null && message.hasOwnProperty("stringVal"))
+        if (message.stringVal != null && Object.hasOwnProperty.call(message, "stringVal"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.stringVal);
         if (message.stringRepeated != null && message.stringRepeated.length)
             for (var i = 0; i < message.stringRepeated.length; ++i)
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.stringRepeated[i]);
-        if (message.uint64Val != null && message.hasOwnProperty("uint64Val"))
+        if (message.uint64Val != null && Object.hasOwnProperty.call(message, "uint64Val"))
             writer.uint32(/* id 3, wireType 0 =*/24).uint64(message.uint64Val);
         if (message.uint64Repeated != null && message.uint64Repeated.length) {
             writer.uint32(/* id 4, wireType 2 =*/34).fork();
@@ -155,12 +155,12 @@ $root.Message = (function() {
                 writer.uint64(message.uint64Repeated[i]);
             writer.ldelim();
         }
-        if (message.bytesVal != null && message.hasOwnProperty("bytesVal"))
+        if (message.bytesVal != null && Object.hasOwnProperty.call(message, "bytesVal"))
             writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.bytesVal);
         if (message.bytesRepeated != null && message.bytesRepeated.length)
             for (var i = 0; i < message.bytesRepeated.length; ++i)
                 writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.bytesRepeated[i]);
-        if (message.enumVal != null && message.hasOwnProperty("enumVal"))
+        if (message.enumVal != null && Object.hasOwnProperty.call(message, "enumVal"))
             writer.uint32(/* id 7, wireType 0 =*/56).int32(message.enumVal);
         if (message.enumRepeated != null && message.enumRepeated.length) {
             writer.uint32(/* id 8, wireType 2 =*/66).fork();
@@ -168,7 +168,7 @@ $root.Message = (function() {
                 writer.int32(message.enumRepeated[i]);
             writer.ldelim();
         }
-        if (message.int64Map != null && message.hasOwnProperty("int64Map"))
+        if (message.int64Map != null && Object.hasOwnProperty.call(message, "int64Map"))
             for (var keys = Object.keys(message.int64Map), i = 0; i < keys.length; ++i)
                 writer.uint32(/* id 9, wireType 2 =*/74).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int64(message.int64Map[keys[i]]).ldelim();
         return writer;

--- a/tests/data/mapbox/vector_tile.d.ts
+++ b/tests/data/mapbox/vector_tile.d.ts
@@ -1,3 +1,5 @@
+import * as Long from "long";
+
 import * as $protobuf from "../../..";
 export namespace vector_tile {
 
@@ -13,10 +15,10 @@ export namespace vector_tile {
         public static encodeDelimited(message: vector_tile.ITile, writer?: $protobuf.Writer): $protobuf.Writer;
         public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): vector_tile.Tile;
         public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): vector_tile.Tile;
-        public static verify(message: { [k: string]: any }): (string|null);
-        public static fromObject(object: { [k: string]: any }): vector_tile.Tile;
-        public static toObject(message: vector_tile.Tile, options?: $protobuf.IConversionOptions): { [k: string]: any };
-        public toJSON(): { [k: string]: any };
+        public static verify(message: { [k: string]: any | undefined }): (string|null);
+        public static fromObject(object: { [k: string]: any | undefined }): vector_tile.Tile;
+        public static toObject(message: vector_tile.Tile, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+        public toJSON(): { [k: string]: any | undefined };
     }
 
     namespace Tile {
@@ -52,10 +54,10 @@ export namespace vector_tile {
             public static encodeDelimited(message: vector_tile.Tile.IValue, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): vector_tile.Tile.Value;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): vector_tile.Tile.Value;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): vector_tile.Tile.Value;
-            public static toObject(message: vector_tile.Tile.Value, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): vector_tile.Tile.Value;
+            public static toObject(message: vector_tile.Tile.Value, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IFeature {
@@ -76,10 +78,10 @@ export namespace vector_tile {
             public static encodeDelimited(message: vector_tile.Tile.IFeature, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): vector_tile.Tile.Feature;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): vector_tile.Tile.Feature;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): vector_tile.Tile.Feature;
-            public static toObject(message: vector_tile.Tile.Feature, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): vector_tile.Tile.Feature;
+            public static toObject(message: vector_tile.Tile.Feature, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface ILayer {
@@ -104,10 +106,10 @@ export namespace vector_tile {
             public static encodeDelimited(message: vector_tile.Tile.ILayer, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): vector_tile.Tile.Layer;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): vector_tile.Tile.Layer;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): vector_tile.Tile.Layer;
-            public static toObject(message: vector_tile.Tile.Layer, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): vector_tile.Tile.Layer;
+            public static toObject(message: vector_tile.Tile.Layer, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
     }
 }

--- a/tests/data/mapbox/vector_tile.js
+++ b/tests/data/mapbox/vector_tile.js
@@ -351,19 +351,19 @@ $root.vector_tile = (function() {
             Value.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.stringValue != null && message.hasOwnProperty("stringValue"))
+                if (message.stringValue != null && Object.hasOwnProperty.call(message, "stringValue"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.stringValue);
-                if (message.floatValue != null && message.hasOwnProperty("floatValue"))
+                if (message.floatValue != null && Object.hasOwnProperty.call(message, "floatValue"))
                     writer.uint32(/* id 2, wireType 5 =*/21).float(message.floatValue);
-                if (message.doubleValue != null && message.hasOwnProperty("doubleValue"))
+                if (message.doubleValue != null && Object.hasOwnProperty.call(message, "doubleValue"))
                     writer.uint32(/* id 3, wireType 1 =*/25).double(message.doubleValue);
-                if (message.intValue != null && message.hasOwnProperty("intValue"))
+                if (message.intValue != null && Object.hasOwnProperty.call(message, "intValue"))
                     writer.uint32(/* id 4, wireType 0 =*/32).int64(message.intValue);
-                if (message.uintValue != null && message.hasOwnProperty("uintValue"))
+                if (message.uintValue != null && Object.hasOwnProperty.call(message, "uintValue"))
                     writer.uint32(/* id 5, wireType 0 =*/40).uint64(message.uintValue);
-                if (message.sintValue != null && message.hasOwnProperty("sintValue"))
+                if (message.sintValue != null && Object.hasOwnProperty.call(message, "sintValue"))
                     writer.uint32(/* id 6, wireType 0 =*/48).sint64(message.sintValue);
-                if (message.boolValue != null && message.hasOwnProperty("boolValue"))
+                if (message.boolValue != null && Object.hasOwnProperty.call(message, "boolValue"))
                     writer.uint32(/* id 7, wireType 0 =*/56).bool(message.boolValue);
                 return writer;
             };
@@ -688,7 +688,7 @@ $root.vector_tile = (function() {
             Feature.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.id != null && message.hasOwnProperty("id"))
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                     writer.uint32(/* id 1, wireType 0 =*/8).uint64(message.id);
                 if (message.tags != null && message.tags.length) {
                     writer.uint32(/* id 2, wireType 2 =*/18).fork();
@@ -696,7 +696,7 @@ $root.vector_tile = (function() {
                         writer.uint32(message.tags[i]);
                     writer.ldelim();
                 }
-                if (message.type != null && message.hasOwnProperty("type"))
+                if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                     writer.uint32(/* id 3, wireType 0 =*/24).int32(message.type);
                 if (message.geometry != null && message.geometry.length) {
                     writer.uint32(/* id 4, wireType 2 =*/34).fork();
@@ -1058,7 +1058,7 @@ $root.vector_tile = (function() {
                 if (message.values != null && message.values.length)
                     for (var i = 0; i < message.values.length; ++i)
                         $root.vector_tile.Tile.Value.encode(message.values[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
-                if (message.extent != null && message.hasOwnProperty("extent"))
+                if (message.extent != null && Object.hasOwnProperty.call(message, "extent"))
                     writer.uint32(/* id 5, wireType 0 =*/40).uint32(message.extent);
                 writer.uint32(/* id 15, wireType 0 =*/120).uint32(message.version);
                 return writer;

--- a/tests/data/package.d.ts
+++ b/tests/data/package.d.ts
@@ -1,3 +1,5 @@
+import * as Long from "long";
+
 import * as $protobuf from "../..";
 export interface IPackage {
     name?: (string|null);
@@ -11,10 +13,10 @@ export interface IPackage {
     homepage?: (string|null);
     keywords?: (string[]|null);
     main?: (string|null);
-    bin?: ({ [k: string]: string }|null);
-    scripts?: ({ [k: string]: string }|null);
-    dependencies?: ({ [k: string]: string }|null);
-    devDependencies?: ({ [k: string]: string }|null);
+    bin?: ({ [k: string]: string | undefined }|null);
+    scripts?: ({ [k: string]: string | undefined }|null);
+    dependencies?: ({ [k: string]: string | undefined }|null);
+    devDependencies?: ({ [k: string]: string | undefined }|null);
     types?: (string|null);
     cliDependencies?: (string[]|null);
 }
@@ -32,10 +34,10 @@ export class Package implements IPackage {
     public homepage: string;
     public keywords: string[];
     public main: string;
-    public bin: { [k: string]: string };
-    public scripts: { [k: string]: string };
-    public dependencies: { [k: string]: string };
-    public devDependencies: { [k: string]: string };
+    public bin: { [k: string]: string | undefined };
+    public scripts: { [k: string]: string | undefined };
+    public dependencies: { [k: string]: string | undefined };
+    public devDependencies: { [k: string]: string | undefined };
     public types: string;
     public cliDependencies: string[];
     public static create(properties?: IPackage): Package;
@@ -43,10 +45,10 @@ export class Package implements IPackage {
     public static encodeDelimited(message: IPackage, writer?: $protobuf.Writer): $protobuf.Writer;
     public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Package;
     public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Package;
-    public static verify(message: { [k: string]: any }): (string|null);
-    public static fromObject(object: { [k: string]: any }): Package;
-    public static toObject(message: Package, options?: $protobuf.IConversionOptions): { [k: string]: any };
-    public toJSON(): { [k: string]: any };
+    public static verify(message: { [k: string]: any | undefined }): (string|null);
+    public static fromObject(object: { [k: string]: any | undefined }): Package;
+    public static toObject(message: Package, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+    public toJSON(): { [k: string]: any | undefined };
 }
 
 export namespace Package {
@@ -65,9 +67,9 @@ export namespace Package {
         public static encodeDelimited(message: Package.IRepository, writer?: $protobuf.Writer): $protobuf.Writer;
         public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Package.Repository;
         public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Package.Repository;
-        public static verify(message: { [k: string]: any }): (string|null);
-        public static fromObject(object: { [k: string]: any }): Package.Repository;
-        public static toObject(message: Package.Repository, options?: $protobuf.IConversionOptions): { [k: string]: any };
-        public toJSON(): { [k: string]: any };
+        public static verify(message: { [k: string]: any | undefined }): (string|null);
+        public static fromObject(object: { [k: string]: any | undefined }): Package.Repository;
+        public static toObject(message: Package.Repository, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+        public toJSON(): { [k: string]: any | undefined };
     }
 }

--- a/tests/data/package.js
+++ b/tests/data/package.js
@@ -215,45 +215,45 @@ $root.Package = (function() {
     Package.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.name != null && message.hasOwnProperty("name"))
+        if (message.name != null && Object.hasOwnProperty.call(message, "name"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-        if (message.version != null && message.hasOwnProperty("version"))
+        if (message.version != null && Object.hasOwnProperty.call(message, "version"))
             writer.uint32(/* id 2, wireType 2 =*/18).string(message.version);
-        if (message.description != null && message.hasOwnProperty("description"))
+        if (message.description != null && Object.hasOwnProperty.call(message, "description"))
             writer.uint32(/* id 3, wireType 2 =*/26).string(message.description);
-        if (message.author != null && message.hasOwnProperty("author"))
+        if (message.author != null && Object.hasOwnProperty.call(message, "author"))
             writer.uint32(/* id 4, wireType 2 =*/34).string(message.author);
-        if (message.license != null && message.hasOwnProperty("license"))
+        if (message.license != null && Object.hasOwnProperty.call(message, "license"))
             writer.uint32(/* id 5, wireType 2 =*/42).string(message.license);
-        if (message.repository != null && message.hasOwnProperty("repository"))
+        if (message.repository != null && Object.hasOwnProperty.call(message, "repository"))
             $root.Package.Repository.encode(message.repository, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
-        if (message.bugs != null && message.hasOwnProperty("bugs"))
+        if (message.bugs != null && Object.hasOwnProperty.call(message, "bugs"))
             writer.uint32(/* id 7, wireType 2 =*/58).string(message.bugs);
-        if (message.homepage != null && message.hasOwnProperty("homepage"))
+        if (message.homepage != null && Object.hasOwnProperty.call(message, "homepage"))
             writer.uint32(/* id 8, wireType 2 =*/66).string(message.homepage);
         if (message.keywords != null && message.keywords.length)
             for (var i = 0; i < message.keywords.length; ++i)
                 writer.uint32(/* id 9, wireType 2 =*/74).string(message.keywords[i]);
-        if (message.main != null && message.hasOwnProperty("main"))
+        if (message.main != null && Object.hasOwnProperty.call(message, "main"))
             writer.uint32(/* id 10, wireType 2 =*/82).string(message.main);
-        if (message.bin != null && message.hasOwnProperty("bin"))
+        if (message.bin != null && Object.hasOwnProperty.call(message, "bin"))
             for (var keys = Object.keys(message.bin), i = 0; i < keys.length; ++i)
                 writer.uint32(/* id 11, wireType 2 =*/90).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.bin[keys[i]]).ldelim();
-        if (message.scripts != null && message.hasOwnProperty("scripts"))
+        if (message.scripts != null && Object.hasOwnProperty.call(message, "scripts"))
             for (var keys = Object.keys(message.scripts), i = 0; i < keys.length; ++i)
                 writer.uint32(/* id 12, wireType 2 =*/98).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.scripts[keys[i]]).ldelim();
-        if (message.dependencies != null && message.hasOwnProperty("dependencies"))
+        if (message.dependencies != null && Object.hasOwnProperty.call(message, "dependencies"))
             for (var keys = Object.keys(message.dependencies), i = 0; i < keys.length; ++i)
                 writer.uint32(/* id 13, wireType 2 =*/106).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.dependencies[keys[i]]).ldelim();
-        if (message.devDependencies != null && message.hasOwnProperty("devDependencies"))
+        if (message.devDependencies != null && Object.hasOwnProperty.call(message, "devDependencies"))
             for (var keys = Object.keys(message.devDependencies), i = 0; i < keys.length; ++i)
                 writer.uint32(/* id 15, wireType 2 =*/122).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.devDependencies[keys[i]]).ldelim();
-        if (message.types != null && message.hasOwnProperty("types"))
+        if (message.types != null && Object.hasOwnProperty.call(message, "types"))
             writer.uint32(/* id 17, wireType 2 =*/138).string(message.types);
         if (message.cliDependencies != null && message.cliDependencies.length)
             for (var i = 0; i < message.cliDependencies.length; ++i)
                 writer.uint32(/* id 18, wireType 2 =*/146).string(message.cliDependencies[i]);
-        if (message.versionScheme != null && message.hasOwnProperty("versionScheme"))
+        if (message.versionScheme != null && Object.hasOwnProperty.call(message, "versionScheme"))
             writer.uint32(/* id 19, wireType 2 =*/154).string(message.versionScheme);
         return writer;
     };
@@ -733,9 +733,9 @@ $root.Package = (function() {
         Repository.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
-            if (message.type != null && message.hasOwnProperty("type"))
+            if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
-            if (message.url != null && message.hasOwnProperty("url"))
+            if (message.url != null && Object.hasOwnProperty.call(message, "url"))
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.url);
             return writer;
         };

--- a/tests/data/rpc-es6.d.ts
+++ b/tests/data/rpc-es6.d.ts
@@ -1,3 +1,5 @@
+import * as Long from "long";
+
 import * as $protobuf from "../..";
 export class MyService extends $protobuf.rpc.Service {
     constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
@@ -23,10 +25,10 @@ export class MyRequest implements IMyRequest {
     public static encodeDelimited(message: IMyRequest, writer?: $protobuf.Writer): $protobuf.Writer;
     public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): MyRequest;
     public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): MyRequest;
-    public static verify(message: { [k: string]: any }): (string|null);
-    public static fromObject(object: { [k: string]: any }): MyRequest;
-    public static toObject(message: MyRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
-    public toJSON(): { [k: string]: any };
+    public static verify(message: { [k: string]: any | undefined }): (string|null);
+    public static fromObject(object: { [k: string]: any | undefined }): MyRequest;
+    public static toObject(message: MyRequest, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+    public toJSON(): { [k: string]: any | undefined };
 }
 
 export interface IMyResponse {
@@ -41,8 +43,8 @@ export class MyResponse implements IMyResponse {
     public static encodeDelimited(message: IMyResponse, writer?: $protobuf.Writer): $protobuf.Writer;
     public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): MyResponse;
     public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): MyResponse;
-    public static verify(message: { [k: string]: any }): (string|null);
-    public static fromObject(object: { [k: string]: any }): MyResponse;
-    public static toObject(message: MyResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
-    public toJSON(): { [k: string]: any };
+    public static verify(message: { [k: string]: any | undefined }): (string|null);
+    public static fromObject(object: { [k: string]: any | undefined }): MyResponse;
+    public static toObject(message: MyResponse, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+    public toJSON(): { [k: string]: any | undefined };
 }

--- a/tests/data/rpc-es6.js
+++ b/tests/data/rpc-es6.js
@@ -131,7 +131,7 @@ export const MyRequest = $root.MyRequest = (() => {
     MyRequest.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.path != null && message.hasOwnProperty("path"))
+        if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
         return writer;
     };
@@ -318,7 +318,7 @@ export const MyResponse = $root.MyResponse = (() => {
     MyResponse.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.status != null && message.hasOwnProperty("status"))
+        if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
         return writer;
     };

--- a/tests/data/rpc-reserved.d.ts
+++ b/tests/data/rpc-reserved.d.ts
@@ -1,3 +1,5 @@
+import * as Long from "long";
+
 import * as $protobuf from "../..";
 export class MyService extends $protobuf.rpc.Service {
     constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
@@ -23,10 +25,10 @@ export class MyRequest implements IMyRequest {
     public static encodeDelimited(message: IMyRequest, writer?: $protobuf.Writer): $protobuf.Writer;
     public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): MyRequest;
     public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): MyRequest;
-    public static verify(message: { [k: string]: any }): (string|null);
-    public static fromObject(object: { [k: string]: any }): MyRequest;
-    public static toObject(message: MyRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
-    public toJSON(): { [k: string]: any };
+    public static verify(message: { [k: string]: any | undefined }): (string|null);
+    public static fromObject(object: { [k: string]: any | undefined }): MyRequest;
+    public static toObject(message: MyRequest, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+    public toJSON(): { [k: string]: any | undefined };
 }
 
 export interface IMyResponse {
@@ -41,8 +43,8 @@ export class MyResponse implements IMyResponse {
     public static encodeDelimited(message: IMyResponse, writer?: $protobuf.Writer): $protobuf.Writer;
     public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): MyResponse;
     public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): MyResponse;
-    public static verify(message: { [k: string]: any }): (string|null);
-    public static fromObject(object: { [k: string]: any }): MyResponse;
-    public static toObject(message: MyResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
-    public toJSON(): { [k: string]: any };
+    public static verify(message: { [k: string]: any | undefined }): (string|null);
+    public static fromObject(object: { [k: string]: any | undefined }): MyResponse;
+    public static toObject(message: MyResponse, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+    public toJSON(): { [k: string]: any | undefined };
 }

--- a/tests/data/rpc-reserved.js
+++ b/tests/data/rpc-reserved.js
@@ -133,7 +133,7 @@ $root.MyRequest = (function() {
     MyRequest.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.path != null && message.hasOwnProperty("path"))
+        if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
         return writer;
     };
@@ -320,7 +320,7 @@ $root.MyResponse = (function() {
     MyResponse.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.status != null && message.hasOwnProperty("status"))
+        if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
         return writer;
     };

--- a/tests/data/rpc.d.ts
+++ b/tests/data/rpc.d.ts
@@ -1,3 +1,5 @@
+import * as Long from "long";
+
 import * as $protobuf from "../..";
 export class MyService extends $protobuf.rpc.Service {
     constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
@@ -23,10 +25,10 @@ export class MyRequest implements IMyRequest {
     public static encodeDelimited(message: IMyRequest, writer?: $protobuf.Writer): $protobuf.Writer;
     public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): MyRequest;
     public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): MyRequest;
-    public static verify(message: { [k: string]: any }): (string|null);
-    public static fromObject(object: { [k: string]: any }): MyRequest;
-    public static toObject(message: MyRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
-    public toJSON(): { [k: string]: any };
+    public static verify(message: { [k: string]: any | undefined }): (string|null);
+    public static fromObject(object: { [k: string]: any | undefined }): MyRequest;
+    public static toObject(message: MyRequest, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+    public toJSON(): { [k: string]: any | undefined };
 }
 
 export interface IMyResponse {
@@ -41,8 +43,8 @@ export class MyResponse implements IMyResponse {
     public static encodeDelimited(message: IMyResponse, writer?: $protobuf.Writer): $protobuf.Writer;
     public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): MyResponse;
     public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): MyResponse;
-    public static verify(message: { [k: string]: any }): (string|null);
-    public static fromObject(object: { [k: string]: any }): MyResponse;
-    public static toObject(message: MyResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
-    public toJSON(): { [k: string]: any };
+    public static verify(message: { [k: string]: any | undefined }): (string|null);
+    public static fromObject(object: { [k: string]: any | undefined }): MyResponse;
+    public static toObject(message: MyResponse, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+    public toJSON(): { [k: string]: any | undefined };
 }

--- a/tests/data/rpc.js
+++ b/tests/data/rpc.js
@@ -133,7 +133,7 @@ $root.MyRequest = (function() {
     MyRequest.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.path != null && message.hasOwnProperty("path"))
+        if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
         return writer;
     };
@@ -320,7 +320,7 @@ $root.MyResponse = (function() {
     MyResponse.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.status != null && message.hasOwnProperty("status"))
+        if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
         return writer;
     };

--- a/tests/data/test.d.ts
+++ b/tests/data/test.d.ts
@@ -1,3 +1,5 @@
+import * as Long from "long";
+
 import * as $protobuf from "../..";
 export namespace jspb {
 
@@ -13,10 +15,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.IEmpty, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.Empty;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.Empty;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.Empty;
-            public static toObject(message: jspb.test.Empty, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.Empty;
+            public static toObject(message: jspb.test.Empty, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         enum OuterEnum {
@@ -36,10 +38,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.IEnumContainer, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.EnumContainer;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.EnumContainer;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.EnumContainer;
-            public static toObject(message: jspb.test.EnumContainer, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.EnumContainer;
+            public static toObject(message: jspb.test.EnumContainer, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface ISimple1 {
@@ -58,10 +60,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.ISimple1, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.Simple1;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.Simple1;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.Simple1;
-            public static toObject(message: jspb.test.Simple1, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.Simple1;
+            public static toObject(message: jspb.test.Simple1, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface ISimple2 {
@@ -78,10 +80,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.ISimple2, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.Simple2;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.Simple2;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.Simple2;
-            public static toObject(message: jspb.test.Simple2, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.Simple2;
+            public static toObject(message: jspb.test.Simple2, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface ISpecialCases {
@@ -102,10 +104,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.ISpecialCases, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.SpecialCases;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.SpecialCases;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.SpecialCases;
-            public static toObject(message: jspb.test.SpecialCases, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.SpecialCases;
+            public static toObject(message: jspb.test.SpecialCases, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IOptionalFields {
@@ -128,10 +130,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.IOptionalFields, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.OptionalFields;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.OptionalFields;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.OptionalFields;
-            public static toObject(message: jspb.test.OptionalFields, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.OptionalFields;
+            public static toObject(message: jspb.test.OptionalFields, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace OptionalFields {
@@ -148,10 +150,10 @@ export namespace jspb {
                 public static encodeDelimited(message: jspb.test.OptionalFields.INested, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.OptionalFields.Nested;
                 public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.OptionalFields.Nested;
-                public static verify(message: { [k: string]: any }): (string|null);
-                public static fromObject(object: { [k: string]: any }): jspb.test.OptionalFields.Nested;
-                public static toObject(message: jspb.test.OptionalFields.Nested, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                public toJSON(): { [k: string]: any };
+                public static verify(message: { [k: string]: any | undefined }): (string|null);
+                public static fromObject(object: { [k: string]: any | undefined }): jspb.test.OptionalFields.Nested;
+                public static toObject(message: jspb.test.OptionalFields.Nested, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                public toJSON(): { [k: string]: any | undefined };
             }
         }
 
@@ -177,10 +179,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.IHasExtensions, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.HasExtensions;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.HasExtensions;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.HasExtensions;
-            public static toObject(message: jspb.test.HasExtensions, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.HasExtensions;
+            public static toObject(message: jspb.test.HasExtensions, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IComplex {
@@ -203,10 +205,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.IComplex, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.Complex;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.Complex;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.Complex;
-            public static toObject(message: jspb.test.Complex, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.Complex;
+            public static toObject(message: jspb.test.Complex, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace Complex {
@@ -223,10 +225,10 @@ export namespace jspb {
                 public static encodeDelimited(message: jspb.test.Complex.INested, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.Complex.Nested;
                 public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.Complex.Nested;
-                public static verify(message: { [k: string]: any }): (string|null);
-                public static fromObject(object: { [k: string]: any }): jspb.test.Complex.Nested;
-                public static toObject(message: jspb.test.Complex.Nested, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                public toJSON(): { [k: string]: any };
+                public static verify(message: { [k: string]: any | undefined }): (string|null);
+                public static fromObject(object: { [k: string]: any | undefined }): jspb.test.Complex.Nested;
+                public static toObject(message: jspb.test.Complex.Nested, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                public toJSON(): { [k: string]: any | undefined };
             }
         }
 
@@ -240,10 +242,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.IOuterMessage, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.OuterMessage;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.OuterMessage;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.OuterMessage;
-            public static toObject(message: jspb.test.OuterMessage, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.OuterMessage;
+            public static toObject(message: jspb.test.OuterMessage, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace OuterMessage {
@@ -260,10 +262,10 @@ export namespace jspb {
                 public static encodeDelimited(message: jspb.test.OuterMessage.IComplex, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.OuterMessage.Complex;
                 public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.OuterMessage.Complex;
-                public static verify(message: { [k: string]: any }): (string|null);
-                public static fromObject(object: { [k: string]: any }): jspb.test.OuterMessage.Complex;
-                public static toObject(message: jspb.test.OuterMessage.Complex, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                public toJSON(): { [k: string]: any };
+                public static verify(message: { [k: string]: any | undefined }): (string|null);
+                public static fromObject(object: { [k: string]: any | undefined }): jspb.test.OuterMessage.Complex;
+                public static toObject(message: jspb.test.OuterMessage.Complex, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                public toJSON(): { [k: string]: any | undefined };
             }
         }
 
@@ -279,10 +281,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.IIsExtension, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.IsExtension;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.IsExtension;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.IsExtension;
-            public static toObject(message: jspb.test.IsExtension, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.IsExtension;
+            public static toObject(message: jspb.test.IsExtension, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IIndirectExtension {
@@ -295,10 +297,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.IIndirectExtension, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.IndirectExtension;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.IndirectExtension;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.IndirectExtension;
-            public static toObject(message: jspb.test.IndirectExtension, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.IndirectExtension;
+            public static toObject(message: jspb.test.IndirectExtension, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IDefaultValues {
@@ -323,10 +325,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.IDefaultValues, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.DefaultValues;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.DefaultValues;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.DefaultValues;
-            public static toObject(message: jspb.test.DefaultValues, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.DefaultValues;
+            public static toObject(message: jspb.test.DefaultValues, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace DefaultValues {
@@ -363,10 +365,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.IFloatingPointFields, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.FloatingPointFields;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.FloatingPointFields;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.FloatingPointFields;
-            public static toObject(message: jspb.test.FloatingPointFields, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.FloatingPointFields;
+            public static toObject(message: jspb.test.FloatingPointFields, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface ITestClone {
@@ -390,10 +392,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.ITestClone, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestClone;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestClone;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.TestClone;
-            public static toObject(message: jspb.test.TestClone, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.TestClone;
+            public static toObject(message: jspb.test.TestClone, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface ICloneExtension {
@@ -408,10 +410,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.ICloneExtension, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.CloneExtension;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.CloneExtension;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.CloneExtension;
-            public static toObject(message: jspb.test.CloneExtension, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.CloneExtension;
+            public static toObject(message: jspb.test.CloneExtension, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface ITestGroup {
@@ -436,10 +438,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.ITestGroup, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestGroup;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestGroup;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.TestGroup;
-            public static toObject(message: jspb.test.TestGroup, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.TestGroup;
+            public static toObject(message: jspb.test.TestGroup, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace TestGroup {
@@ -458,10 +460,10 @@ export namespace jspb {
                 public static encodeDelimited(message: jspb.test.TestGroup.IRepeatedGroup, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestGroup.RepeatedGroup;
                 public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestGroup.RepeatedGroup;
-                public static verify(message: { [k: string]: any }): (string|null);
-                public static fromObject(object: { [k: string]: any }): jspb.test.TestGroup.RepeatedGroup;
-                public static toObject(message: jspb.test.TestGroup.RepeatedGroup, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                public toJSON(): { [k: string]: any };
+                public static verify(message: { [k: string]: any | undefined }): (string|null);
+                public static fromObject(object: { [k: string]: any | undefined }): jspb.test.TestGroup.RepeatedGroup;
+                public static toObject(message: jspb.test.TestGroup.RepeatedGroup, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                public toJSON(): { [k: string]: any | undefined };
             }
 
             interface IRequiredGroup {
@@ -476,10 +478,10 @@ export namespace jspb {
                 public static encodeDelimited(message: jspb.test.TestGroup.IRequiredGroup, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestGroup.RequiredGroup;
                 public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestGroup.RequiredGroup;
-                public static verify(message: { [k: string]: any }): (string|null);
-                public static fromObject(object: { [k: string]: any }): jspb.test.TestGroup.RequiredGroup;
-                public static toObject(message: jspb.test.TestGroup.RequiredGroup, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                public toJSON(): { [k: string]: any };
+                public static verify(message: { [k: string]: any | undefined }): (string|null);
+                public static fromObject(object: { [k: string]: any | undefined }): jspb.test.TestGroup.RequiredGroup;
+                public static toObject(message: jspb.test.TestGroup.RequiredGroup, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                public toJSON(): { [k: string]: any | undefined };
             }
 
             interface IOptionalGroup {
@@ -494,10 +496,10 @@ export namespace jspb {
                 public static encodeDelimited(message: jspb.test.TestGroup.IOptionalGroup, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestGroup.OptionalGroup;
                 public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestGroup.OptionalGroup;
-                public static verify(message: { [k: string]: any }): (string|null);
-                public static fromObject(object: { [k: string]: any }): jspb.test.TestGroup.OptionalGroup;
-                public static toObject(message: jspb.test.TestGroup.OptionalGroup, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                public toJSON(): { [k: string]: any };
+                public static verify(message: { [k: string]: any | undefined }): (string|null);
+                public static fromObject(object: { [k: string]: any | undefined }): jspb.test.TestGroup.OptionalGroup;
+                public static toObject(message: jspb.test.TestGroup.OptionalGroup, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                public toJSON(): { [k: string]: any | undefined };
             }
         }
 
@@ -513,10 +515,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.ITestGroup1, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestGroup1;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestGroup1;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.TestGroup1;
-            public static toObject(message: jspb.test.TestGroup1, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.TestGroup1;
+            public static toObject(message: jspb.test.TestGroup1, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface ITestReservedNames {
@@ -532,10 +534,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.ITestReservedNames, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestReservedNames;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestReservedNames;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.TestReservedNames;
-            public static toObject(message: jspb.test.TestReservedNames, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.TestReservedNames;
+            public static toObject(message: jspb.test.TestReservedNames, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface ITestReservedNamesExtension {
@@ -548,10 +550,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.ITestReservedNamesExtension, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestReservedNamesExtension;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestReservedNamesExtension;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.TestReservedNamesExtension;
-            public static toObject(message: jspb.test.TestReservedNamesExtension, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.TestReservedNamesExtension;
+            public static toObject(message: jspb.test.TestReservedNamesExtension, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface ITestMessageWithOneof {
@@ -588,10 +590,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.ITestMessageWithOneof, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestMessageWithOneof;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestMessageWithOneof;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.TestMessageWithOneof;
-            public static toObject(message: jspb.test.TestMessageWithOneof, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.TestMessageWithOneof;
+            public static toObject(message: jspb.test.TestMessageWithOneof, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface ITestEndsWithBytes {
@@ -608,50 +610,50 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.ITestEndsWithBytes, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestEndsWithBytes;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestEndsWithBytes;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.TestEndsWithBytes;
-            public static toObject(message: jspb.test.TestEndsWithBytes, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.TestEndsWithBytes;
+            public static toObject(message: jspb.test.TestEndsWithBytes, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface ITestMapFieldsNoBinary {
-            mapStringString?: ({ [k: string]: string }|null);
-            mapStringInt32?: ({ [k: string]: number }|null);
-            mapStringInt64?: ({ [k: string]: (number|Long) }|null);
-            mapStringBool?: ({ [k: string]: boolean }|null);
-            mapStringDouble?: ({ [k: string]: number }|null);
-            mapStringEnum?: ({ [k: string]: jspb.test.MapValueEnumNoBinary }|null);
-            mapStringMsg?: ({ [k: string]: jspb.test.IMapValueMessageNoBinary }|null);
-            mapInt32String?: ({ [k: string]: string }|null);
-            mapInt64String?: ({ [k: string]: string }|null);
-            mapBoolString?: ({ [k: string]: string }|null);
+            mapStringString?: ({ [k: string]: string | undefined }|null);
+            mapStringInt32?: ({ [k: string]: number | undefined }|null);
+            mapStringInt64?: ({ [k: string]: (number|Long) | undefined }|null);
+            mapStringBool?: ({ [k: string]: boolean | undefined }|null);
+            mapStringDouble?: ({ [k: string]: number | undefined }|null);
+            mapStringEnum?: ({ [k: string]: jspb.test.MapValueEnumNoBinary | undefined }|null);
+            mapStringMsg?: ({ [k: string]: jspb.test.IMapValueMessageNoBinary | undefined }|null);
+            mapInt32String?: ({ [k: string]: string | undefined }|null);
+            mapInt64String?: ({ [k: string]: string | undefined }|null);
+            mapBoolString?: ({ [k: string]: string | undefined }|null);
             testMapFields?: (jspb.test.ITestMapFieldsNoBinary|null);
-            mapStringTestmapfields?: ({ [k: string]: jspb.test.ITestMapFieldsNoBinary }|null);
+            mapStringTestmapfields?: ({ [k: string]: jspb.test.ITestMapFieldsNoBinary | undefined }|null);
         }
 
         class TestMapFieldsNoBinary implements ITestMapFieldsNoBinary {
             constructor(properties?: jspb.test.ITestMapFieldsNoBinary);
-            public mapStringString: { [k: string]: string };
-            public mapStringInt32: { [k: string]: number };
-            public mapStringInt64: { [k: string]: (number|Long) };
-            public mapStringBool: { [k: string]: boolean };
-            public mapStringDouble: { [k: string]: number };
-            public mapStringEnum: { [k: string]: jspb.test.MapValueEnumNoBinary };
-            public mapStringMsg: { [k: string]: jspb.test.IMapValueMessageNoBinary };
-            public mapInt32String: { [k: string]: string };
-            public mapInt64String: { [k: string]: string };
-            public mapBoolString: { [k: string]: string };
+            public mapStringString: { [k: string]: string | undefined };
+            public mapStringInt32: { [k: string]: number | undefined };
+            public mapStringInt64: { [k: string]: (number|Long) | undefined };
+            public mapStringBool: { [k: string]: boolean | undefined };
+            public mapStringDouble: { [k: string]: number | undefined };
+            public mapStringEnum: { [k: string]: jspb.test.MapValueEnumNoBinary | undefined };
+            public mapStringMsg: { [k: string]: jspb.test.IMapValueMessageNoBinary | undefined };
+            public mapInt32String: { [k: string]: string | undefined };
+            public mapInt64String: { [k: string]: string | undefined };
+            public mapBoolString: { [k: string]: string | undefined };
             public testMapFields?: (jspb.test.ITestMapFieldsNoBinary|null);
-            public mapStringTestmapfields: { [k: string]: jspb.test.ITestMapFieldsNoBinary };
+            public mapStringTestmapfields: { [k: string]: jspb.test.ITestMapFieldsNoBinary | undefined };
             public static create(properties?: jspb.test.ITestMapFieldsNoBinary): jspb.test.TestMapFieldsNoBinary;
             public static encode(message: jspb.test.ITestMapFieldsNoBinary, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: jspb.test.ITestMapFieldsNoBinary, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestMapFieldsNoBinary;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestMapFieldsNoBinary;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.TestMapFieldsNoBinary;
-            public static toObject(message: jspb.test.TestMapFieldsNoBinary, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.TestMapFieldsNoBinary;
+            public static toObject(message: jspb.test.TestMapFieldsNoBinary, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         enum MapValueEnumNoBinary {
@@ -672,10 +674,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.IMapValueMessageNoBinary, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.MapValueMessageNoBinary;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.MapValueMessageNoBinary;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.MapValueMessageNoBinary;
-            public static toObject(message: jspb.test.MapValueMessageNoBinary, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.MapValueMessageNoBinary;
+            public static toObject(message: jspb.test.MapValueMessageNoBinary, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IDeeply {
@@ -688,10 +690,10 @@ export namespace jspb {
             public static encodeDelimited(message: jspb.test.IDeeply, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.Deeply;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.Deeply;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): jspb.test.Deeply;
-            public static toObject(message: jspb.test.Deeply, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): jspb.test.Deeply;
+            public static toObject(message: jspb.test.Deeply, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace Deeply {
@@ -706,10 +708,10 @@ export namespace jspb {
                 public static encodeDelimited(message: jspb.test.Deeply.INested, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.Deeply.Nested;
                 public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.Deeply.Nested;
-                public static verify(message: { [k: string]: any }): (string|null);
-                public static fromObject(object: { [k: string]: any }): jspb.test.Deeply.Nested;
-                public static toObject(message: jspb.test.Deeply.Nested, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                public toJSON(): { [k: string]: any };
+                public static verify(message: { [k: string]: any | undefined }): (string|null);
+                public static fromObject(object: { [k: string]: any | undefined }): jspb.test.Deeply.Nested;
+                public static toObject(message: jspb.test.Deeply.Nested, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                public toJSON(): { [k: string]: any | undefined };
             }
 
             namespace Nested {
@@ -726,10 +728,10 @@ export namespace jspb {
                     public static encodeDelimited(message: jspb.test.Deeply.Nested.IMessage, writer?: $protobuf.Writer): $protobuf.Writer;
                     public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.Deeply.Nested.Message;
                     public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.Deeply.Nested.Message;
-                    public static verify(message: { [k: string]: any }): (string|null);
-                    public static fromObject(object: { [k: string]: any }): jspb.test.Deeply.Nested.Message;
-                    public static toObject(message: jspb.test.Deeply.Nested.Message, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                    public toJSON(): { [k: string]: any };
+                    public static verify(message: { [k: string]: any | undefined }): (string|null);
+                    public static fromObject(object: { [k: string]: any | undefined }): jspb.test.Deeply.Nested.Message;
+                    public static toObject(message: jspb.test.Deeply.Nested.Message, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                    public toJSON(): { [k: string]: any | undefined };
                 }
             }
         }
@@ -752,10 +754,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IFileDescriptorSet, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.FileDescriptorSet;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.FileDescriptorSet;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.FileDescriptorSet;
-            public static toObject(message: google.protobuf.FileDescriptorSet, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.FileDescriptorSet;
+            public static toObject(message: google.protobuf.FileDescriptorSet, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IFileDescriptorProto {
@@ -792,10 +794,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IFileDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.FileDescriptorProto;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.FileDescriptorProto;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.FileDescriptorProto;
-            public static toObject(message: google.protobuf.FileDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.FileDescriptorProto;
+            public static toObject(message: google.protobuf.FileDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IDescriptorProto {
@@ -828,10 +830,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.DescriptorProto;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.DescriptorProto;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.DescriptorProto;
-            public static toObject(message: google.protobuf.DescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.DescriptorProto;
+            public static toObject(message: google.protobuf.DescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace DescriptorProto {
@@ -850,10 +852,10 @@ export namespace google {
                 public static encodeDelimited(message: google.protobuf.DescriptorProto.IExtensionRange, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.DescriptorProto.ExtensionRange;
                 public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.DescriptorProto.ExtensionRange;
-                public static verify(message: { [k: string]: any }): (string|null);
-                public static fromObject(object: { [k: string]: any }): google.protobuf.DescriptorProto.ExtensionRange;
-                public static toObject(message: google.protobuf.DescriptorProto.ExtensionRange, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                public toJSON(): { [k: string]: any };
+                public static verify(message: { [k: string]: any | undefined }): (string|null);
+                public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.DescriptorProto.ExtensionRange;
+                public static toObject(message: google.protobuf.DescriptorProto.ExtensionRange, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                public toJSON(): { [k: string]: any | undefined };
             }
 
             interface IReservedRange {
@@ -870,10 +872,10 @@ export namespace google {
                 public static encodeDelimited(message: google.protobuf.DescriptorProto.IReservedRange, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.DescriptorProto.ReservedRange;
                 public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.DescriptorProto.ReservedRange;
-                public static verify(message: { [k: string]: any }): (string|null);
-                public static fromObject(object: { [k: string]: any }): google.protobuf.DescriptorProto.ReservedRange;
-                public static toObject(message: google.protobuf.DescriptorProto.ReservedRange, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                public toJSON(): { [k: string]: any };
+                public static verify(message: { [k: string]: any | undefined }): (string|null);
+                public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.DescriptorProto.ReservedRange;
+                public static toObject(message: google.protobuf.DescriptorProto.ReservedRange, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                public toJSON(): { [k: string]: any | undefined };
             }
         }
 
@@ -907,10 +909,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IFieldDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.FieldDescriptorProto;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.FieldDescriptorProto;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.FieldDescriptorProto;
-            public static toObject(message: google.protobuf.FieldDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.FieldDescriptorProto;
+            public static toObject(message: google.protobuf.FieldDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace FieldDescriptorProto {
@@ -957,10 +959,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IOneofDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.OneofDescriptorProto;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.OneofDescriptorProto;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.OneofDescriptorProto;
-            public static toObject(message: google.protobuf.OneofDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.OneofDescriptorProto;
+            public static toObject(message: google.protobuf.OneofDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IEnumDescriptorProto {
@@ -979,10 +981,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IEnumDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.EnumDescriptorProto;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.EnumDescriptorProto;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.EnumDescriptorProto;
-            public static toObject(message: google.protobuf.EnumDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.EnumDescriptorProto;
+            public static toObject(message: google.protobuf.EnumDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IEnumValueDescriptorProto {
@@ -1001,10 +1003,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IEnumValueDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.EnumValueDescriptorProto;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.EnumValueDescriptorProto;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.EnumValueDescriptorProto;
-            public static toObject(message: google.protobuf.EnumValueDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.EnumValueDescriptorProto;
+            public static toObject(message: google.protobuf.EnumValueDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IServiceDescriptorProto {
@@ -1023,10 +1025,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IServiceDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.ServiceDescriptorProto;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.ServiceDescriptorProto;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.ServiceDescriptorProto;
-            public static toObject(message: google.protobuf.ServiceDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.ServiceDescriptorProto;
+            public static toObject(message: google.protobuf.ServiceDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IMethodDescriptorProto {
@@ -1051,10 +1053,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IMethodDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.MethodDescriptorProto;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.MethodDescriptorProto;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.MethodDescriptorProto;
-            public static toObject(message: google.protobuf.MethodDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.MethodDescriptorProto;
+            public static toObject(message: google.protobuf.MethodDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IFileOptions {
@@ -1097,10 +1099,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IFileOptions, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.FileOptions;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.FileOptions;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.FileOptions;
-            public static toObject(message: google.protobuf.FileOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.FileOptions;
+            public static toObject(message: google.protobuf.FileOptions, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace FileOptions {
@@ -1132,10 +1134,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IMessageOptions, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.MessageOptions;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.MessageOptions;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.MessageOptions;
-            public static toObject(message: google.protobuf.MessageOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.MessageOptions;
+            public static toObject(message: google.protobuf.MessageOptions, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IFieldOptions {
@@ -1162,10 +1164,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IFieldOptions, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.FieldOptions;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.FieldOptions;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.FieldOptions;
-            public static toObject(message: google.protobuf.FieldOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.FieldOptions;
+            public static toObject(message: google.protobuf.FieldOptions, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace FieldOptions {
@@ -1195,10 +1197,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IOneofOptions, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.OneofOptions;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.OneofOptions;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.OneofOptions;
-            public static toObject(message: google.protobuf.OneofOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.OneofOptions;
+            public static toObject(message: google.protobuf.OneofOptions, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IEnumOptions {
@@ -1218,10 +1220,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IEnumOptions, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.EnumOptions;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.EnumOptions;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.EnumOptions;
-            public static toObject(message: google.protobuf.EnumOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.EnumOptions;
+            public static toObject(message: google.protobuf.EnumOptions, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IEnumValueOptions {
@@ -1238,10 +1240,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IEnumValueOptions, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.EnumValueOptions;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.EnumValueOptions;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.EnumValueOptions;
-            public static toObject(message: google.protobuf.EnumValueOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.EnumValueOptions;
+            public static toObject(message: google.protobuf.EnumValueOptions, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IServiceOptions {
@@ -1258,10 +1260,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IServiceOptions, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.ServiceOptions;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.ServiceOptions;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.ServiceOptions;
-            public static toObject(message: google.protobuf.ServiceOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.ServiceOptions;
+            public static toObject(message: google.protobuf.ServiceOptions, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         interface IMethodOptions {
@@ -1280,10 +1282,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IMethodOptions, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.MethodOptions;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.MethodOptions;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.MethodOptions;
-            public static toObject(message: google.protobuf.MethodOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.MethodOptions;
+            public static toObject(message: google.protobuf.MethodOptions, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace MethodOptions {
@@ -1319,10 +1321,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IUninterpretedOption, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.UninterpretedOption;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.UninterpretedOption;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.UninterpretedOption;
-            public static toObject(message: google.protobuf.UninterpretedOption, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.UninterpretedOption;
+            public static toObject(message: google.protobuf.UninterpretedOption, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace UninterpretedOption {
@@ -1341,10 +1343,10 @@ export namespace google {
                 public static encodeDelimited(message: google.protobuf.UninterpretedOption.INamePart, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.UninterpretedOption.NamePart;
                 public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.UninterpretedOption.NamePart;
-                public static verify(message: { [k: string]: any }): (string|null);
-                public static fromObject(object: { [k: string]: any }): google.protobuf.UninterpretedOption.NamePart;
-                public static toObject(message: google.protobuf.UninterpretedOption.NamePart, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                public toJSON(): { [k: string]: any };
+                public static verify(message: { [k: string]: any | undefined }): (string|null);
+                public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.UninterpretedOption.NamePart;
+                public static toObject(message: google.protobuf.UninterpretedOption.NamePart, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                public toJSON(): { [k: string]: any | undefined };
             }
         }
 
@@ -1360,10 +1362,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.ISourceCodeInfo, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.SourceCodeInfo;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.SourceCodeInfo;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.SourceCodeInfo;
-            public static toObject(message: google.protobuf.SourceCodeInfo, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.SourceCodeInfo;
+            public static toObject(message: google.protobuf.SourceCodeInfo, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace SourceCodeInfo {
@@ -1388,10 +1390,10 @@ export namespace google {
                 public static encodeDelimited(message: google.protobuf.SourceCodeInfo.ILocation, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.SourceCodeInfo.Location;
                 public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.SourceCodeInfo.Location;
-                public static verify(message: { [k: string]: any }): (string|null);
-                public static fromObject(object: { [k: string]: any }): google.protobuf.SourceCodeInfo.Location;
-                public static toObject(message: google.protobuf.SourceCodeInfo.Location, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                public toJSON(): { [k: string]: any };
+                public static verify(message: { [k: string]: any | undefined }): (string|null);
+                public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.SourceCodeInfo.Location;
+                public static toObject(message: google.protobuf.SourceCodeInfo.Location, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                public toJSON(): { [k: string]: any | undefined };
             }
         }
 
@@ -1407,10 +1409,10 @@ export namespace google {
             public static encodeDelimited(message: google.protobuf.IGeneratedCodeInfo, writer?: $protobuf.Writer): $protobuf.Writer;
             public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.GeneratedCodeInfo;
             public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.GeneratedCodeInfo;
-            public static verify(message: { [k: string]: any }): (string|null);
-            public static fromObject(object: { [k: string]: any }): google.protobuf.GeneratedCodeInfo;
-            public static toObject(message: google.protobuf.GeneratedCodeInfo, options?: $protobuf.IConversionOptions): { [k: string]: any };
-            public toJSON(): { [k: string]: any };
+            public static verify(message: { [k: string]: any | undefined }): (string|null);
+            public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.GeneratedCodeInfo;
+            public static toObject(message: google.protobuf.GeneratedCodeInfo, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+            public toJSON(): { [k: string]: any | undefined };
         }
 
         namespace GeneratedCodeInfo {
@@ -1433,10 +1435,10 @@ export namespace google {
                 public static encodeDelimited(message: google.protobuf.GeneratedCodeInfo.IAnnotation, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.GeneratedCodeInfo.Annotation;
                 public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.GeneratedCodeInfo.Annotation;
-                public static verify(message: { [k: string]: any }): (string|null);
-                public static fromObject(object: { [k: string]: any }): google.protobuf.GeneratedCodeInfo.Annotation;
-                public static toObject(message: google.protobuf.GeneratedCodeInfo.Annotation, options?: $protobuf.IConversionOptions): { [k: string]: any };
-                public toJSON(): { [k: string]: any };
+                public static verify(message: { [k: string]: any | undefined }): (string|null);
+                public static fromObject(object: { [k: string]: any | undefined }): google.protobuf.GeneratedCodeInfo.Annotation;
+                public static toObject(message: google.protobuf.GeneratedCodeInfo.Annotation, options?: $protobuf.IConversionOptions): { [k: string]: any | undefined };
+                public toJSON(): { [k: string]: any | undefined };
             }
         }
     }

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -257,7 +257,7 @@ $root.jspb = (function() {
             EnumContainer.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.outerEnum != null && message.hasOwnProperty("outerEnum"))
+                if (message.outerEnum != null && Object.hasOwnProperty.call(message, "outerEnum"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.outerEnum);
                 return writer;
             };
@@ -480,7 +480,7 @@ $root.jspb = (function() {
                 if (message.aRepeatedString != null && message.aRepeatedString.length)
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.aRepeatedString[i]);
-                if (message.aBoolean != null && message.hasOwnProperty("aBoolean"))
+                if (message.aBoolean != null && Object.hasOwnProperty.call(message, "aBoolean"))
                     writer.uint32(/* id 3, wireType 0 =*/24).bool(message.aBoolean);
                 return writer;
             };
@@ -1224,10 +1224,10 @@ $root.jspb = (function() {
             OptionalFields.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.aString != null && message.hasOwnProperty("aString"))
+                if (message.aString != null && Object.hasOwnProperty.call(message, "aString"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.aString);
                 writer.uint32(/* id 2, wireType 0 =*/16).bool(message.aBool);
-                if (message.aNestedMessage != null && message.hasOwnProperty("aNestedMessage"))
+                if (message.aNestedMessage != null && Object.hasOwnProperty.call(message, "aNestedMessage"))
                     $root.jspb.test.OptionalFields.Nested.encode(message.aNestedMessage, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                 if (message.aRepeatedMessage != null && message.aRepeatedMessage.length)
                     for (var i = 0; i < message.aRepeatedMessage.length; ++i)
@@ -1503,7 +1503,7 @@ $root.jspb = (function() {
                 Nested.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.anInt != null && message.hasOwnProperty("anInt"))
+                    if (message.anInt != null && Object.hasOwnProperty.call(message, "anInt"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.anInt);
                     return writer;
                 };
@@ -1767,17 +1767,17 @@ $root.jspb = (function() {
             HasExtensions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.str1 != null && message.hasOwnProperty("str1"))
+                if (message.str1 != null && Object.hasOwnProperty.call(message, "str1"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.str1);
-                if (message.str2 != null && message.hasOwnProperty("str2"))
+                if (message.str2 != null && Object.hasOwnProperty.call(message, "str2"))
                     writer.uint32(/* id 2, wireType 2 =*/18).string(message.str2);
-                if (message.str3 != null && message.hasOwnProperty("str3"))
+                if (message.str3 != null && Object.hasOwnProperty.call(message, "str3"))
                     writer.uint32(/* id 3, wireType 2 =*/26).string(message.str3);
-                if (message[".jspb.test.IsExtension.extField"] != null && message.hasOwnProperty(".jspb.test.IsExtension.extField"))
+                if (message[".jspb.test.IsExtension.extField"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IsExtension.extField"))
                     $root.jspb.test.IsExtension.encode(message[".jspb.test.IsExtension.extField"], writer.uint32(/* id 100, wireType 2 =*/802).fork()).ldelim();
-                if (message[".jspb.test.IndirectExtension.simple"] != null && message.hasOwnProperty(".jspb.test.IndirectExtension.simple"))
+                if (message[".jspb.test.IndirectExtension.simple"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IndirectExtension.simple"))
                     $root.jspb.test.Simple1.encode(message[".jspb.test.IndirectExtension.simple"], writer.uint32(/* id 101, wireType 2 =*/810).fork()).ldelim();
-                if (message[".jspb.test.IndirectExtension.str"] != null && message.hasOwnProperty(".jspb.test.IndirectExtension.str"))
+                if (message[".jspb.test.IndirectExtension.str"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IndirectExtension.str"))
                     writer.uint32(/* id 102, wireType 2 =*/818).string(message[".jspb.test.IndirectExtension.str"]);
                 if (message[".jspb.test.IndirectExtension.repeatedStr"] != null && message[".jspb.test.IndirectExtension.repeatedStr"].length)
                     for (var i = 0; i < message[".jspb.test.IndirectExtension.repeatedStr"].length; ++i)
@@ -1785,7 +1785,7 @@ $root.jspb = (function() {
                 if (message[".jspb.test.IndirectExtension.repeatedSimple"] != null && message[".jspb.test.IndirectExtension.repeatedSimple"].length)
                     for (var i = 0; i < message[".jspb.test.IndirectExtension.repeatedSimple"].length; ++i)
                         $root.jspb.test.Simple1.encode(message[".jspb.test.IndirectExtension.repeatedSimple"][i], writer.uint32(/* id 104, wireType 2 =*/834).fork()).ldelim();
-                if (message[".jspb.test.simple1"] != null && message.hasOwnProperty(".jspb.test.simple1"))
+                if (message[".jspb.test.simple1"] != null && Object.hasOwnProperty.call(message, ".jspb.test.simple1"))
                     $root.jspb.test.Simple1.encode(message[".jspb.test.simple1"], writer.uint32(/* id 105, wireType 2 =*/842).fork()).ldelim();
                 return writer;
             };
@@ -2150,7 +2150,7 @@ $root.jspb = (function() {
                 if (!writer)
                     writer = $Writer.create();
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.aString);
-                if (message.aNestedMessage != null && message.hasOwnProperty("aNestedMessage"))
+                if (message.aNestedMessage != null && Object.hasOwnProperty.call(message, "aNestedMessage"))
                     $root.jspb.test.Complex.Nested.encode(message.aNestedMessage, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
                 if (message.aRepeatedMessage != null && message.aRepeatedMessage.length)
                     for (var i = 0; i < message.aRepeatedMessage.length; ++i)
@@ -2775,7 +2775,7 @@ $root.jspb = (function() {
                 Complex.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.innerComplexField != null && message.hasOwnProperty("innerComplexField"))
+                    if (message.innerComplexField != null && Object.hasOwnProperty.call(message, "innerComplexField"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.innerComplexField);
                     return writer;
                 };
@@ -2965,7 +2965,7 @@ $root.jspb = (function() {
             IsExtension.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.ext1 != null && message.hasOwnProperty("ext1"))
+                if (message.ext1 != null && Object.hasOwnProperty.call(message, "ext1"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.ext1);
                 return writer;
             };
@@ -3357,17 +3357,17 @@ $root.jspb = (function() {
             DefaultValues.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.stringField != null && message.hasOwnProperty("stringField"))
+                if (message.stringField != null && Object.hasOwnProperty.call(message, "stringField"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.stringField);
-                if (message.boolField != null && message.hasOwnProperty("boolField"))
+                if (message.boolField != null && Object.hasOwnProperty.call(message, "boolField"))
                     writer.uint32(/* id 2, wireType 0 =*/16).bool(message.boolField);
-                if (message.intField != null && message.hasOwnProperty("intField"))
+                if (message.intField != null && Object.hasOwnProperty.call(message, "intField"))
                     writer.uint32(/* id 3, wireType 0 =*/24).int64(message.intField);
-                if (message.enumField != null && message.hasOwnProperty("enumField"))
+                if (message.enumField != null && Object.hasOwnProperty.call(message, "enumField"))
                     writer.uint32(/* id 4, wireType 0 =*/32).int32(message.enumField);
-                if (message.emptyField != null && message.hasOwnProperty("emptyField"))
+                if (message.emptyField != null && Object.hasOwnProperty.call(message, "emptyField"))
                     writer.uint32(/* id 6, wireType 2 =*/50).string(message.emptyField);
-                if (message.bytesField != null && message.hasOwnProperty("bytesField"))
+                if (message.bytesField != null && Object.hasOwnProperty.call(message, "bytesField"))
                     writer.uint32(/* id 8, wireType 2 =*/66).bytes(message.bytesField);
                 return writer;
             };
@@ -3729,21 +3729,21 @@ $root.jspb = (function() {
             FloatingPointFields.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.optionalFloatField != null && message.hasOwnProperty("optionalFloatField"))
+                if (message.optionalFloatField != null && Object.hasOwnProperty.call(message, "optionalFloatField"))
                     writer.uint32(/* id 1, wireType 5 =*/13).float(message.optionalFloatField);
                 writer.uint32(/* id 2, wireType 5 =*/21).float(message.requiredFloatField);
                 if (message.repeatedFloatField != null && message.repeatedFloatField.length)
                     for (var i = 0; i < message.repeatedFloatField.length; ++i)
                         writer.uint32(/* id 3, wireType 5 =*/29).float(message.repeatedFloatField[i]);
-                if (message.defaultFloatField != null && message.hasOwnProperty("defaultFloatField"))
+                if (message.defaultFloatField != null && Object.hasOwnProperty.call(message, "defaultFloatField"))
                     writer.uint32(/* id 4, wireType 5 =*/37).float(message.defaultFloatField);
-                if (message.optionalDoubleField != null && message.hasOwnProperty("optionalDoubleField"))
+                if (message.optionalDoubleField != null && Object.hasOwnProperty.call(message, "optionalDoubleField"))
                     writer.uint32(/* id 5, wireType 1 =*/41).double(message.optionalDoubleField);
                 writer.uint32(/* id 6, wireType 1 =*/49).double(message.requiredDoubleField);
                 if (message.repeatedDoubleField != null && message.repeatedDoubleField.length)
                     for (var i = 0; i < message.repeatedDoubleField.length; ++i)
                         writer.uint32(/* id 7, wireType 1 =*/57).double(message.repeatedDoubleField[i]);
-                if (message.defaultDoubleField != null && message.hasOwnProperty("defaultDoubleField"))
+                if (message.defaultDoubleField != null && Object.hasOwnProperty.call(message, "defaultDoubleField"))
                     writer.uint32(/* id 8, wireType 1 =*/65).double(message.defaultDoubleField);
                 return writer;
             };
@@ -4096,18 +4096,18 @@ $root.jspb = (function() {
             TestClone.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.str != null && message.hasOwnProperty("str"))
+                if (message.str != null && Object.hasOwnProperty.call(message, "str"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.str);
-                if (message.simple1 != null && message.hasOwnProperty("simple1"))
+                if (message.simple1 != null && Object.hasOwnProperty.call(message, "simple1"))
                     $root.jspb.test.Simple1.encode(message.simple1, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                 if (message.simple2 != null && message.simple2.length)
                     for (var i = 0; i < message.simple2.length; ++i)
                         $root.jspb.test.Simple1.encode(message.simple2[i], writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
-                if (message.bytesField != null && message.hasOwnProperty("bytesField"))
+                if (message.bytesField != null && Object.hasOwnProperty.call(message, "bytesField"))
                     writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.bytesField);
-                if (message.unused != null && message.hasOwnProperty("unused"))
+                if (message.unused != null && Object.hasOwnProperty.call(message, "unused"))
                     writer.uint32(/* id 7, wireType 2 =*/58).string(message.unused);
-                if (message[".jspb.test.CloneExtension.extField"] != null && message.hasOwnProperty(".jspb.test.CloneExtension.extField"))
+                if (message[".jspb.test.CloneExtension.extField"] != null && Object.hasOwnProperty.call(message, ".jspb.test.CloneExtension.extField"))
                     $root.jspb.test.CloneExtension.encode(message[".jspb.test.CloneExtension.extField"], writer.uint32(/* id 100, wireType 2 =*/802).fork()).ldelim();
                 return writer;
             };
@@ -4389,7 +4389,7 @@ $root.jspb = (function() {
             CloneExtension.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.ext != null && message.hasOwnProperty("ext"))
+                if (message.ext != null && Object.hasOwnProperty.call(message, "ext"))
                     writer.uint32(/* id 2, wireType 2 =*/18).string(message.ext);
                 return writer;
             };
@@ -4626,12 +4626,12 @@ $root.jspb = (function() {
                     for (var i = 0; i < message.repeatedGroup.length; ++i)
                         $root.jspb.test.TestGroup.RepeatedGroup.encode(message.repeatedGroup[i], writer.uint32(/* id 1, wireType 3 =*/11)).uint32(/* id 1, wireType 4 =*/12);
                 $root.jspb.test.TestGroup.RequiredGroup.encode(message.requiredGroup, writer.uint32(/* id 2, wireType 3 =*/19)).uint32(/* id 2, wireType 4 =*/20);
-                if (message.optionalGroup != null && message.hasOwnProperty("optionalGroup"))
+                if (message.optionalGroup != null && Object.hasOwnProperty.call(message, "optionalGroup"))
                     $root.jspb.test.TestGroup.OptionalGroup.encode(message.optionalGroup, writer.uint32(/* id 3, wireType 3 =*/27)).uint32(/* id 3, wireType 4 =*/28);
-                if (message.id != null && message.hasOwnProperty("id"))
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                     writer.uint32(/* id 4, wireType 2 =*/34).string(message.id);
                 $root.jspb.test.Simple2.encode(message.requiredSimple, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
-                if (message.optionalSimple != null && message.hasOwnProperty("optionalSimple"))
+                if (message.optionalSimple != null && Object.hasOwnProperty.call(message, "optionalSimple"))
                     $root.jspb.test.Simple2.encode(message.optionalSimple, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
                 return writer;
             };
@@ -5529,7 +5529,7 @@ $root.jspb = (function() {
             TestGroup1.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.group != null && message.hasOwnProperty("group"))
+                if (message.group != null && Object.hasOwnProperty.call(message, "group"))
                     $root.jspb.test.TestGroup.RepeatedGroup.encode(message.group, writer.uint32(/* id 1, wireType 3 =*/11)).uint32(/* id 1, wireType 4 =*/12);
                 return writer;
             };
@@ -5730,9 +5730,9 @@ $root.jspb = (function() {
             TestReservedNames.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.extension != null && message.hasOwnProperty("extension"))
+                if (message.extension != null && Object.hasOwnProperty.call(message, "extension"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.extension);
-                if (message[".jspb.test.TestReservedNamesExtension.foo"] != null && message.hasOwnProperty(".jspb.test.TestReservedNamesExtension.foo"))
+                if (message[".jspb.test.TestReservedNamesExtension.foo"] != null && Object.hasOwnProperty.call(message, ".jspb.test.TestReservedNamesExtension.foo"))
                     writer.uint32(/* id 10, wireType 0 =*/80).int32(message[".jspb.test.TestReservedNamesExtension.foo"]);
                 return writer;
             };
@@ -6220,26 +6220,26 @@ $root.jspb = (function() {
             TestMessageWithOneof.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.pone != null && message.hasOwnProperty("pone"))
+                if (message.pone != null && Object.hasOwnProperty.call(message, "pone"))
                     writer.uint32(/* id 3, wireType 2 =*/26).string(message.pone);
-                if (message.pthree != null && message.hasOwnProperty("pthree"))
+                if (message.pthree != null && Object.hasOwnProperty.call(message, "pthree"))
                     writer.uint32(/* id 5, wireType 2 =*/42).string(message.pthree);
-                if (message.rone != null && message.hasOwnProperty("rone"))
+                if (message.rone != null && Object.hasOwnProperty.call(message, "rone"))
                     $root.jspb.test.TestMessageWithOneof.encode(message.rone, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
-                if (message.rtwo != null && message.hasOwnProperty("rtwo"))
+                if (message.rtwo != null && Object.hasOwnProperty.call(message, "rtwo"))
                     writer.uint32(/* id 7, wireType 2 =*/58).string(message.rtwo);
-                if (message.normalField != null && message.hasOwnProperty("normalField"))
+                if (message.normalField != null && Object.hasOwnProperty.call(message, "normalField"))
                     writer.uint32(/* id 8, wireType 0 =*/64).bool(message.normalField);
                 if (message.repeatedField != null && message.repeatedField.length)
                     for (var i = 0; i < message.repeatedField.length; ++i)
                         writer.uint32(/* id 9, wireType 2 =*/74).string(message.repeatedField[i]);
-                if (message.aone != null && message.hasOwnProperty("aone"))
+                if (message.aone != null && Object.hasOwnProperty.call(message, "aone"))
                     writer.uint32(/* id 10, wireType 0 =*/80).int32(message.aone);
-                if (message.atwo != null && message.hasOwnProperty("atwo"))
+                if (message.atwo != null && Object.hasOwnProperty.call(message, "atwo"))
                     writer.uint32(/* id 11, wireType 0 =*/88).int32(message.atwo);
-                if (message.bone != null && message.hasOwnProperty("bone"))
+                if (message.bone != null && Object.hasOwnProperty.call(message, "bone"))
                     writer.uint32(/* id 12, wireType 0 =*/96).int32(message.bone);
-                if (message.btwo != null && message.hasOwnProperty("btwo"))
+                if (message.btwo != null && Object.hasOwnProperty.call(message, "btwo"))
                     writer.uint32(/* id 13, wireType 0 =*/104).int32(message.btwo);
                 return writer;
             };
@@ -6596,9 +6596,9 @@ $root.jspb = (function() {
             TestEndsWithBytes.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.value != null && message.hasOwnProperty("value"))
+                if (message.value != null && Object.hasOwnProperty.call(message, "value"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.value);
-                if (message.data != null && message.hasOwnProperty("data"))
+                if (message.data != null && Object.hasOwnProperty.call(message, "data"))
                     writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.data);
                 return writer;
             };
@@ -6916,41 +6916,41 @@ $root.jspb = (function() {
             TestMapFieldsNoBinary.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.mapStringString != null && message.hasOwnProperty("mapStringString"))
+                if (message.mapStringString != null && Object.hasOwnProperty.call(message, "mapStringString"))
                     for (var keys = Object.keys(message.mapStringString), i = 0; i < keys.length; ++i)
                         writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.mapStringString[keys[i]]).ldelim();
-                if (message.mapStringInt32 != null && message.hasOwnProperty("mapStringInt32"))
+                if (message.mapStringInt32 != null && Object.hasOwnProperty.call(message, "mapStringInt32"))
                     for (var keys = Object.keys(message.mapStringInt32), i = 0; i < keys.length; ++i)
                         writer.uint32(/* id 2, wireType 2 =*/18).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int32(message.mapStringInt32[keys[i]]).ldelim();
-                if (message.mapStringInt64 != null && message.hasOwnProperty("mapStringInt64"))
+                if (message.mapStringInt64 != null && Object.hasOwnProperty.call(message, "mapStringInt64"))
                     for (var keys = Object.keys(message.mapStringInt64), i = 0; i < keys.length; ++i)
                         writer.uint32(/* id 3, wireType 2 =*/26).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int64(message.mapStringInt64[keys[i]]).ldelim();
-                if (message.mapStringBool != null && message.hasOwnProperty("mapStringBool"))
+                if (message.mapStringBool != null && Object.hasOwnProperty.call(message, "mapStringBool"))
                     for (var keys = Object.keys(message.mapStringBool), i = 0; i < keys.length; ++i)
                         writer.uint32(/* id 4, wireType 2 =*/34).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).bool(message.mapStringBool[keys[i]]).ldelim();
-                if (message.mapStringDouble != null && message.hasOwnProperty("mapStringDouble"))
+                if (message.mapStringDouble != null && Object.hasOwnProperty.call(message, "mapStringDouble"))
                     for (var keys = Object.keys(message.mapStringDouble), i = 0; i < keys.length; ++i)
                         writer.uint32(/* id 5, wireType 2 =*/42).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 1 =*/17).double(message.mapStringDouble[keys[i]]).ldelim();
-                if (message.mapStringEnum != null && message.hasOwnProperty("mapStringEnum"))
+                if (message.mapStringEnum != null && Object.hasOwnProperty.call(message, "mapStringEnum"))
                     for (var keys = Object.keys(message.mapStringEnum), i = 0; i < keys.length; ++i)
                         writer.uint32(/* id 6, wireType 2 =*/50).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int32(message.mapStringEnum[keys[i]]).ldelim();
-                if (message.mapStringMsg != null && message.hasOwnProperty("mapStringMsg"))
+                if (message.mapStringMsg != null && Object.hasOwnProperty.call(message, "mapStringMsg"))
                     for (var keys = Object.keys(message.mapStringMsg), i = 0; i < keys.length; ++i) {
                         writer.uint32(/* id 7, wireType 2 =*/58).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
                         $root.jspb.test.MapValueMessageNoBinary.encode(message.mapStringMsg[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim().ldelim();
                     }
-                if (message.mapInt32String != null && message.hasOwnProperty("mapInt32String"))
+                if (message.mapInt32String != null && Object.hasOwnProperty.call(message, "mapInt32String"))
                     for (var keys = Object.keys(message.mapInt32String), i = 0; i < keys.length; ++i)
                         writer.uint32(/* id 8, wireType 2 =*/66).fork().uint32(/* id 1, wireType 0 =*/8).int32(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.mapInt32String[keys[i]]).ldelim();
-                if (message.mapInt64String != null && message.hasOwnProperty("mapInt64String"))
+                if (message.mapInt64String != null && Object.hasOwnProperty.call(message, "mapInt64String"))
                     for (var keys = Object.keys(message.mapInt64String), i = 0; i < keys.length; ++i)
                         writer.uint32(/* id 9, wireType 2 =*/74).fork().uint32(/* id 1, wireType 0 =*/8).int64(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.mapInt64String[keys[i]]).ldelim();
-                if (message.mapBoolString != null && message.hasOwnProperty("mapBoolString"))
+                if (message.mapBoolString != null && Object.hasOwnProperty.call(message, "mapBoolString"))
                     for (var keys = Object.keys(message.mapBoolString), i = 0; i < keys.length; ++i)
                         writer.uint32(/* id 10, wireType 2 =*/82).fork().uint32(/* id 1, wireType 0 =*/8).bool(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.mapBoolString[keys[i]]).ldelim();
-                if (message.testMapFields != null && message.hasOwnProperty("testMapFields"))
+                if (message.testMapFields != null && Object.hasOwnProperty.call(message, "testMapFields"))
                     $root.jspb.test.TestMapFieldsNoBinary.encode(message.testMapFields, writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
-                if (message.mapStringTestmapfields != null && message.hasOwnProperty("mapStringTestmapfields"))
+                if (message.mapStringTestmapfields != null && Object.hasOwnProperty.call(message, "mapStringTestmapfields"))
                     for (var keys = Object.keys(message.mapStringTestmapfields), i = 0; i < keys.length; ++i) {
                         writer.uint32(/* id 12, wireType 2 =*/98).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
                         $root.jspb.test.TestMapFieldsNoBinary.encode(message.mapStringTestmapfields[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim().ldelim();
@@ -7531,7 +7531,7 @@ $root.jspb = (function() {
             MapValueMessageNoBinary.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.foo != null && message.hasOwnProperty("foo"))
+                if (message.foo != null && Object.hasOwnProperty.call(message, "foo"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.foo);
                 return writer;
             };
@@ -8032,7 +8032,7 @@ $root.jspb = (function() {
                     Message.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.count != null && message.hasOwnProperty("count"))
+                        if (message.count != null && Object.hasOwnProperty.call(message, "count"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int32(message.count);
                         return writer;
                     };
@@ -8563,9 +8563,9 @@ $root.google = (function() {
             FileDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                if (message["package"] != null && message.hasOwnProperty("package"))
+                if (message["package"] != null && Object.hasOwnProperty.call(message, "package"))
                     writer.uint32(/* id 2, wireType 2 =*/18).string(message["package"]);
                 if (message.dependency != null && message.dependency.length)
                     for (var i = 0; i < message.dependency.length; ++i)
@@ -8582,9 +8582,9 @@ $root.google = (function() {
                 if (message.extension != null && message.extension.length)
                     for (var i = 0; i < message.extension.length; ++i)
                         $root.google.protobuf.FieldDescriptorProto.encode(message.extension[i], writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.FileOptions.encode(message.options, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
-                if (message.sourceCodeInfo != null && message.hasOwnProperty("sourceCodeInfo"))
+                if (message.sourceCodeInfo != null && Object.hasOwnProperty.call(message, "sourceCodeInfo"))
                     $root.google.protobuf.SourceCodeInfo.encode(message.sourceCodeInfo, writer.uint32(/* id 9, wireType 2 =*/74).fork()).ldelim();
                 if (message.publicDependency != null && message.publicDependency.length)
                     for (var i = 0; i < message.publicDependency.length; ++i)
@@ -8592,7 +8592,7 @@ $root.google = (function() {
                 if (message.weakDependency != null && message.weakDependency.length)
                     for (var i = 0; i < message.weakDependency.length; ++i)
                         writer.uint32(/* id 11, wireType 0 =*/88).int32(message.weakDependency[i]);
-                if (message.syntax != null && message.hasOwnProperty("syntax"))
+                if (message.syntax != null && Object.hasOwnProperty.call(message, "syntax"))
                     writer.uint32(/* id 12, wireType 2 =*/98).string(message.syntax);
                 return writer;
             };
@@ -9130,7 +9130,7 @@ $root.google = (function() {
             DescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.field != null && message.field.length)
                     for (var i = 0; i < message.field.length; ++i)
@@ -9147,7 +9147,7 @@ $root.google = (function() {
                 if (message.extension != null && message.extension.length)
                     for (var i = 0; i < message.extension.length; ++i)
                         $root.google.protobuf.FieldDescriptorProto.encode(message.extension[i], writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.MessageOptions.encode(message.options, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
                 if (message.oneofDecl != null && message.oneofDecl.length)
                     for (var i = 0; i < message.oneofDecl.length; ++i)
@@ -9603,9 +9603,9 @@ $root.google = (function() {
                 ExtensionRange.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.start != null && message.hasOwnProperty("start"))
+                    if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
-                    if (message.end != null && message.hasOwnProperty("end"))
+                    if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
                     return writer;
                 };
@@ -9813,9 +9813,9 @@ $root.google = (function() {
                 ReservedRange.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.start != null && message.hasOwnProperty("start"))
+                    if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
-                    if (message.end != null && message.hasOwnProperty("end"))
+                    if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
                     return writer;
                 };
@@ -10098,25 +10098,25 @@ $root.google = (function() {
             FieldDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                if (message.extendee != null && message.hasOwnProperty("extendee"))
+                if (message.extendee != null && Object.hasOwnProperty.call(message, "extendee"))
                     writer.uint32(/* id 2, wireType 2 =*/18).string(message.extendee);
-                if (message.number != null && message.hasOwnProperty("number"))
+                if (message.number != null && Object.hasOwnProperty.call(message, "number"))
                     writer.uint32(/* id 3, wireType 0 =*/24).int32(message.number);
-                if (message.label != null && message.hasOwnProperty("label"))
+                if (message.label != null && Object.hasOwnProperty.call(message, "label"))
                     writer.uint32(/* id 4, wireType 0 =*/32).int32(message.label);
-                if (message.type != null && message.hasOwnProperty("type"))
+                if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                     writer.uint32(/* id 5, wireType 0 =*/40).int32(message.type);
-                if (message.typeName != null && message.hasOwnProperty("typeName"))
+                if (message.typeName != null && Object.hasOwnProperty.call(message, "typeName"))
                     writer.uint32(/* id 6, wireType 2 =*/50).string(message.typeName);
-                if (message.defaultValue != null && message.hasOwnProperty("defaultValue"))
+                if (message.defaultValue != null && Object.hasOwnProperty.call(message, "defaultValue"))
                     writer.uint32(/* id 7, wireType 2 =*/58).string(message.defaultValue);
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.FieldOptions.encode(message.options, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
-                if (message.oneofIndex != null && message.hasOwnProperty("oneofIndex"))
+                if (message.oneofIndex != null && Object.hasOwnProperty.call(message, "oneofIndex"))
                     writer.uint32(/* id 9, wireType 0 =*/72).int32(message.oneofIndex);
-                if (message.jsonName != null && message.hasOwnProperty("jsonName"))
+                if (message.jsonName != null && Object.hasOwnProperty.call(message, "jsonName"))
                     writer.uint32(/* id 10, wireType 2 =*/82).string(message.jsonName);
                 return writer;
             };
@@ -10590,9 +10590,9 @@ $root.google = (function() {
             OneofDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.OneofOptions.encode(message.options, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                 return writer;
             };
@@ -10815,12 +10815,12 @@ $root.google = (function() {
             EnumDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.value != null && message.value.length)
                     for (var i = 0; i < message.value.length; ++i)
                         $root.google.protobuf.EnumValueDescriptorProto.encode(message.value[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.EnumOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                 return writer;
             };
@@ -11073,11 +11073,11 @@ $root.google = (function() {
             EnumValueDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                if (message.number != null && message.hasOwnProperty("number"))
+                if (message.number != null && Object.hasOwnProperty.call(message, "number"))
                     writer.uint32(/* id 2, wireType 0 =*/16).int32(message.number);
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.EnumValueOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                 return writer;
             };
@@ -11311,12 +11311,12 @@ $root.google = (function() {
             ServiceDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.method != null && message.method.length)
                     for (var i = 0; i < message.method.length; ++i)
                         $root.google.protobuf.MethodDescriptorProto.encode(message.method[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.ServiceOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                 return writer;
             };
@@ -11596,17 +11596,17 @@ $root.google = (function() {
             MethodDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                if (message.inputType != null && message.hasOwnProperty("inputType"))
+                if (message.inputType != null && Object.hasOwnProperty.call(message, "inputType"))
                     writer.uint32(/* id 2, wireType 2 =*/18).string(message.inputType);
-                if (message.outputType != null && message.hasOwnProperty("outputType"))
+                if (message.outputType != null && Object.hasOwnProperty.call(message, "outputType"))
                     writer.uint32(/* id 3, wireType 2 =*/26).string(message.outputType);
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.MethodOptions.encode(message.options, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
-                if (message.clientStreaming != null && message.hasOwnProperty("clientStreaming"))
+                if (message.clientStreaming != null && Object.hasOwnProperty.call(message, "clientStreaming"))
                     writer.uint32(/* id 5, wireType 0 =*/40).bool(message.clientStreaming);
-                if (message.serverStreaming != null && message.hasOwnProperty("serverStreaming"))
+                if (message.serverStreaming != null && Object.hasOwnProperty.call(message, "serverStreaming"))
                     writer.uint32(/* id 6, wireType 0 =*/48).bool(message.serverStreaming);
                 return writer;
             };
@@ -11981,33 +11981,33 @@ $root.google = (function() {
             FileOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.javaPackage != null && message.hasOwnProperty("javaPackage"))
+                if (message.javaPackage != null && Object.hasOwnProperty.call(message, "javaPackage"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.javaPackage);
-                if (message.javaOuterClassname != null && message.hasOwnProperty("javaOuterClassname"))
+                if (message.javaOuterClassname != null && Object.hasOwnProperty.call(message, "javaOuterClassname"))
                     writer.uint32(/* id 8, wireType 2 =*/66).string(message.javaOuterClassname);
-                if (message.optimizeFor != null && message.hasOwnProperty("optimizeFor"))
+                if (message.optimizeFor != null && Object.hasOwnProperty.call(message, "optimizeFor"))
                     writer.uint32(/* id 9, wireType 0 =*/72).int32(message.optimizeFor);
-                if (message.javaMultipleFiles != null && message.hasOwnProperty("javaMultipleFiles"))
+                if (message.javaMultipleFiles != null && Object.hasOwnProperty.call(message, "javaMultipleFiles"))
                     writer.uint32(/* id 10, wireType 0 =*/80).bool(message.javaMultipleFiles);
-                if (message.goPackage != null && message.hasOwnProperty("goPackage"))
+                if (message.goPackage != null && Object.hasOwnProperty.call(message, "goPackage"))
                     writer.uint32(/* id 11, wireType 2 =*/90).string(message.goPackage);
-                if (message.ccGenericServices != null && message.hasOwnProperty("ccGenericServices"))
+                if (message.ccGenericServices != null && Object.hasOwnProperty.call(message, "ccGenericServices"))
                     writer.uint32(/* id 16, wireType 0 =*/128).bool(message.ccGenericServices);
-                if (message.javaGenericServices != null && message.hasOwnProperty("javaGenericServices"))
+                if (message.javaGenericServices != null && Object.hasOwnProperty.call(message, "javaGenericServices"))
                     writer.uint32(/* id 17, wireType 0 =*/136).bool(message.javaGenericServices);
-                if (message.pyGenericServices != null && message.hasOwnProperty("pyGenericServices"))
+                if (message.pyGenericServices != null && Object.hasOwnProperty.call(message, "pyGenericServices"))
                     writer.uint32(/* id 18, wireType 0 =*/144).bool(message.pyGenericServices);
-                if (message.javaGenerateEqualsAndHash != null && message.hasOwnProperty("javaGenerateEqualsAndHash"))
+                if (message.javaGenerateEqualsAndHash != null && Object.hasOwnProperty.call(message, "javaGenerateEqualsAndHash"))
                     writer.uint32(/* id 20, wireType 0 =*/160).bool(message.javaGenerateEqualsAndHash);
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 23, wireType 0 =*/184).bool(message.deprecated);
-                if (message.javaStringCheckUtf8 != null && message.hasOwnProperty("javaStringCheckUtf8"))
+                if (message.javaStringCheckUtf8 != null && Object.hasOwnProperty.call(message, "javaStringCheckUtf8"))
                     writer.uint32(/* id 27, wireType 0 =*/216).bool(message.javaStringCheckUtf8);
-                if (message.ccEnableArenas != null && message.hasOwnProperty("ccEnableArenas"))
+                if (message.ccEnableArenas != null && Object.hasOwnProperty.call(message, "ccEnableArenas"))
                     writer.uint32(/* id 31, wireType 0 =*/248).bool(message.ccEnableArenas);
-                if (message.objcClassPrefix != null && message.hasOwnProperty("objcClassPrefix"))
+                if (message.objcClassPrefix != null && Object.hasOwnProperty.call(message, "objcClassPrefix"))
                     writer.uint32(/* id 36, wireType 2 =*/290).string(message.objcClassPrefix);
-                if (message.csharpNamespace != null && message.hasOwnProperty("csharpNamespace"))
+                if (message.csharpNamespace != null && Object.hasOwnProperty.call(message, "csharpNamespace"))
                     writer.uint32(/* id 37, wireType 2 =*/298).string(message.csharpNamespace);
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
@@ -12443,13 +12443,13 @@ $root.google = (function() {
             MessageOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.messageSetWireFormat != null && message.hasOwnProperty("messageSetWireFormat"))
+                if (message.messageSetWireFormat != null && Object.hasOwnProperty.call(message, "messageSetWireFormat"))
                     writer.uint32(/* id 1, wireType 0 =*/8).bool(message.messageSetWireFormat);
-                if (message.noStandardDescriptorAccessor != null && message.hasOwnProperty("noStandardDescriptorAccessor"))
+                if (message.noStandardDescriptorAccessor != null && Object.hasOwnProperty.call(message, "noStandardDescriptorAccessor"))
                     writer.uint32(/* id 2, wireType 0 =*/16).bool(message.noStandardDescriptorAccessor);
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 3, wireType 0 =*/24).bool(message.deprecated);
-                if (message.mapEntry != null && message.hasOwnProperty("mapEntry"))
+                if (message.mapEntry != null && Object.hasOwnProperty.call(message, "mapEntry"))
                     writer.uint32(/* id 7, wireType 0 =*/56).bool(message.mapEntry);
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
@@ -12759,17 +12759,17 @@ $root.google = (function() {
             FieldOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.ctype != null && message.hasOwnProperty("ctype"))
+                if (message.ctype != null && Object.hasOwnProperty.call(message, "ctype"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.ctype);
-                if (message.packed != null && message.hasOwnProperty("packed"))
+                if (message.packed != null && Object.hasOwnProperty.call(message, "packed"))
                     writer.uint32(/* id 2, wireType 0 =*/16).bool(message.packed);
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 3, wireType 0 =*/24).bool(message.deprecated);
-                if (message.lazy != null && message.hasOwnProperty("lazy"))
+                if (message.lazy != null && Object.hasOwnProperty.call(message, "lazy"))
                     writer.uint32(/* id 5, wireType 0 =*/40).bool(message.lazy);
-                if (message.jstype != null && message.hasOwnProperty("jstype"))
+                if (message.jstype != null && Object.hasOwnProperty.call(message, "jstype"))
                     writer.uint32(/* id 6, wireType 0 =*/48).int32(message.jstype);
-                if (message.weak != null && message.hasOwnProperty("weak"))
+                if (message.weak != null && Object.hasOwnProperty.call(message, "weak"))
                     writer.uint32(/* id 10, wireType 0 =*/80).bool(message.weak);
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
@@ -13350,14 +13350,14 @@ $root.google = (function() {
             EnumOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.allowAlias != null && message.hasOwnProperty("allowAlias"))
+                if (message.allowAlias != null && Object.hasOwnProperty.call(message, "allowAlias"))
                     writer.uint32(/* id 2, wireType 0 =*/16).bool(message.allowAlias);
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 3, wireType 0 =*/24).bool(message.deprecated);
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
-                if (message[".jspb.test.IsExtension.simpleOption"] != null && message.hasOwnProperty(".jspb.test.IsExtension.simpleOption"))
+                if (message[".jspb.test.IsExtension.simpleOption"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IsExtension.simpleOption"))
                     writer.uint32(/* id 42113038, wireType 2 =*/336904306).string(message[".jspb.test.IsExtension.simpleOption"]);
                 return writer;
             };
@@ -13608,7 +13608,7 @@ $root.google = (function() {
             EnumValueOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 1, wireType 0 =*/8).bool(message.deprecated);
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
@@ -13839,7 +13839,7 @@ $root.google = (function() {
             ServiceOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 33, wireType 0 =*/264).bool(message.deprecated);
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
@@ -14079,9 +14079,9 @@ $root.google = (function() {
             MethodOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 33, wireType 0 =*/264).bool(message.deprecated);
-                if (message.idempotencyLevel != null && message.hasOwnProperty("idempotencyLevel"))
+                if (message.idempotencyLevel != null && Object.hasOwnProperty.call(message, "idempotencyLevel"))
                     writer.uint32(/* id 34, wireType 0 =*/272).int32(message.idempotencyLevel);
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
@@ -14406,17 +14406,17 @@ $root.google = (function() {
                 if (message.name != null && message.name.length)
                     for (var i = 0; i < message.name.length; ++i)
                         $root.google.protobuf.UninterpretedOption.NamePart.encode(message.name[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                if (message.identifierValue != null && message.hasOwnProperty("identifierValue"))
+                if (message.identifierValue != null && Object.hasOwnProperty.call(message, "identifierValue"))
                     writer.uint32(/* id 3, wireType 2 =*/26).string(message.identifierValue);
-                if (message.positiveIntValue != null && message.hasOwnProperty("positiveIntValue"))
+                if (message.positiveIntValue != null && Object.hasOwnProperty.call(message, "positiveIntValue"))
                     writer.uint32(/* id 4, wireType 0 =*/32).uint64(message.positiveIntValue);
-                if (message.negativeIntValue != null && message.hasOwnProperty("negativeIntValue"))
+                if (message.negativeIntValue != null && Object.hasOwnProperty.call(message, "negativeIntValue"))
                     writer.uint32(/* id 5, wireType 0 =*/40).int64(message.negativeIntValue);
-                if (message.doubleValue != null && message.hasOwnProperty("doubleValue"))
+                if (message.doubleValue != null && Object.hasOwnProperty.call(message, "doubleValue"))
                     writer.uint32(/* id 6, wireType 1 =*/49).double(message.doubleValue);
-                if (message.stringValue != null && message.hasOwnProperty("stringValue"))
+                if (message.stringValue != null && Object.hasOwnProperty.call(message, "stringValue"))
                     writer.uint32(/* id 7, wireType 2 =*/58).bytes(message.stringValue);
-                if (message.aggregateValue != null && message.hasOwnProperty("aggregateValue"))
+                if (message.aggregateValue != null && Object.hasOwnProperty.call(message, "aggregateValue"))
                     writer.uint32(/* id 8, wireType 2 =*/66).string(message.aggregateValue);
                 return writer;
             };
@@ -15193,9 +15193,9 @@ $root.google = (function() {
                             writer.int32(message.span[i]);
                         writer.ldelim();
                     }
-                    if (message.leadingComments != null && message.hasOwnProperty("leadingComments"))
+                    if (message.leadingComments != null && Object.hasOwnProperty.call(message, "leadingComments"))
                         writer.uint32(/* id 3, wireType 2 =*/26).string(message.leadingComments);
-                    if (message.trailingComments != null && message.hasOwnProperty("trailingComments"))
+                    if (message.trailingComments != null && Object.hasOwnProperty.call(message, "trailingComments"))
                         writer.uint32(/* id 4, wireType 2 =*/34).string(message.trailingComments);
                     if (message.leadingDetachedComments != null && message.leadingDetachedComments.length)
                         for (var i = 0; i < message.leadingDetachedComments.length; ++i)
@@ -15726,11 +15726,11 @@ $root.google = (function() {
                             writer.int32(message.path[i]);
                         writer.ldelim();
                     }
-                    if (message.sourceFile != null && message.hasOwnProperty("sourceFile"))
+                    if (message.sourceFile != null && Object.hasOwnProperty.call(message, "sourceFile"))
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.sourceFile);
-                    if (message.begin != null && message.hasOwnProperty("begin"))
+                    if (message.begin != null && Object.hasOwnProperty.call(message, "begin"))
                         writer.uint32(/* id 3, wireType 0 =*/24).int32(message.begin);
-                    if (message.end != null && message.hasOwnProperty("end"))
+                    if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         writer.uint32(/* id 4, wireType 0 =*/32).int32(message.end);
                     return writer;
                 };


### PR DESCRIPTION
The type `{[k: string]: number}` implies that if you look up ANY string in the
object, you will definitely get a number. This is not appropriate for finite
protobufs.

I regenerated some files with `npm run build && npm run types && node
scripts/gentests.js` though I don't really understand what the tests/data files
are used for.