### PR TITLE
Added long to peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [1.0.5](https://github.com/apollographql/protobuf.js/releases/tag/1.0.5)
+
+## Other
+[:hash:](https://github.com/apollographql/protobuf.js/commit/68a467e01363bd3d8140a495d4ed4edeaca4f180) Map field TypeScript types shouldn't imply all keys exist<br />
+
 # [1.0.4](https://github.com/apollographql/protobuf.js/releases/tag/1.0.4)
 
 ## New

--- a/cli/package.standalone.json
+++ b/cli/package.standalone.json
@@ -15,7 +15,7 @@
     "pbts": "bin/pbts"
   },
   "peerDependencies": {
-    "@apollo/protobufjs": "~1.0.4"
+    "@apollo/protobufjs": "~1.0.5"
   },
   "dependencies": {
     "chalk": "^1.1.3",

--- a/dist/light/protobuf.js
+++ b/dist/light/protobuf.js
@@ -1,6 +1,6 @@
 /*!
- * protobuf.js v1.0.4 (c) 2016, daniel wirtz
- * compiled thu, 13 aug 2020 23:19:10 utc
+ * protobuf.js v1.0.5 (c) 2016, daniel wirtz
+ * compiled fri, 14 aug 2020 05:32:49 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/light/protobuf.min.js
+++ b/dist/light/protobuf.min.js
@@ -1,6 +1,6 @@
 /*!
- * protobuf.js v1.0.4 (c) 2016, daniel wirtz
- * compiled thu, 13 aug 2020 23:19:10 utc
+ * protobuf.js v1.0.5 (c) 2016, daniel wirtz
+ * compiled fri, 14 aug 2020 05:32:50 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/minimal/protobuf.js
+++ b/dist/minimal/protobuf.js
@@ -1,6 +1,6 @@
 /*!
- * protobuf.js v1.0.4 (c) 2016, daniel wirtz
- * compiled thu, 13 aug 2020 23:19:10 utc
+ * protobuf.js v1.0.5 (c) 2016, daniel wirtz
+ * compiled fri, 14 aug 2020 05:32:49 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/minimal/protobuf.min.js
+++ b/dist/minimal/protobuf.min.js
@@ -1,6 +1,6 @@
 /*!
- * protobuf.js v1.0.4 (c) 2016, daniel wirtz
- * compiled thu, 13 aug 2020 23:19:10 utc
+ * protobuf.js v1.0.5 (c) 2016, daniel wirtz
+ * compiled fri, 14 aug 2020 05:32:50 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/protobuf.js
+++ b/dist/protobuf.js
@@ -1,6 +1,6 @@
 /*!
- * protobuf.js v1.0.4 (c) 2016, daniel wirtz
- * compiled thu, 13 aug 2020 23:19:10 utc
+ * protobuf.js v1.0.5 (c) 2016, daniel wirtz
+ * compiled fri, 14 aug 2020 05:32:49 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/dist/protobuf.min.js
+++ b/dist/protobuf.min.js
@@ -1,6 +1,6 @@
 /*!
- * protobuf.js v1.0.4 (c) 2016, daniel wirtz
- * compiled thu, 13 aug 2020 23:19:10 utc
+ * protobuf.js v1.0.5 (c) 2016, daniel wirtz
+ * compiled fri, 14 aug 2020 05:32:50 utc
  * licensed under the bsd-3-clause license
  * see: https://github.com/apollographql/protobuf.js for details
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/protobufjs",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/protobufjs",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "versionScheme": "~",
   "description": "Protocol Buffers for JavaScript (& TypeScript).",
   "author": "Daniel Wirtz <dcode+protobufjs@dcode.io>",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,9 @@
     "vinyl-fs": "^3.0.3",
     "vinyl-source-stream": "^2.0.0"
   },
+  "peerDependencies": {
+    "long": "^4.0.0"
+  },
   "cliDependencies": [
     "semver",
     "chalk",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,16 @@
     "vinyl-source-stream": "^2.0.0"
   },
   "peerDependencies": {
+    "@types/long": "4.0.0",
     "long": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/long": {
+      "optional": true
+    },
+    "long": {
+      "optional": true
+    }
   },
   "cliDependencies": [
     "semver",


### PR DESCRIPTION
https://github.com/apollographql/protobuf.js/blob/757f6e3a6ccad26bde1192d4eb9da7d0ff0e8b2e/cli/pbts.js#L155

`long` is included in the emitted (TypeScript) code and so should be a peer dependency.