### PR TITLE
fix: remove long import

### DIFF
--- a/cli/pbts.js
+++ b/cli/pbts.js
@@ -151,10 +151,7 @@ exports.main = function(args, callback) {
                     "// DO NOT EDIT! This is a generated file. Edit the JSDoc in src/*.js instead and run 'npm run types'.",
                     ""
                 );
-            output.push(
-                "import * as Long from \"long\";",
-                ""
-            );               
+
             if (argv.global)
                 output.push(
                     "export as namespace " + argv.global + ";",


### PR DESCRIPTION
In the base repo the PR that added this **was eventually reverted**:
https://github.com/protobufjs/protobuf.js/pull/1166

`@apollo/protobufjs` package is only used by `apollo-reporting-protobuf` which explicitly forces only numbers to be used, and actually disables `Long` entirely (via `--force-number`):

https://github.com/apollographql/apollo-server/blob/fe7df736abdb6bcebf2353902f1b40bee2f9ea5c/packages/apollo-reporting-protobuf/package.json#L10
https://github.com/apollographql/apollo-server/blob/fe7df736abdb6bcebf2353902f1b40bee2f9ea5c/packages/apollo-reporting-protobuf/src/index.js#L4-L8

Without this change, `Long` is unnecessarily added as an import to the typescript definitions:
https://cdn.jsdelivr.net/npm/apollo-reporting-protobuf@0.6.2/dist/protobuf.d.ts

Note that if you search for long in the file, there are no mentions of it besides the first line/import.

Keeping the import there breaks stricter package managers, such as Yarn 2 in PnP mode:

```
../../.yarn/cache/apollo-reporting-protobuf-npm-0.6.2-87872b385d-6e00d36475.zip/node_modules/apollo-reporting-protobuf/dist/protobuf.d.ts(1,23): error TS2307: Cannot find module 'long' or its corresponding type declarations.
```

Requiring to work [around it via `packageExtensions`](https://yarnpkg.com/getting-started/migration/#fix-dependencies-with-packageextensions)

`Long` can be added back in the future to the `.d.ts`, if ever needed, via a cli argument (`-i Long`). As per:
https://github.com/apollographql/protobuf.js/blob/master/cli/pbts.js#L176-L179

This PR supersedes #6 which attempts to solve the same problem.