### PR TITLE
fix: @types/node@^10.1.0 -> @types/node@>=10.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@protobufjs/pool": "^1.1.0",
     "@protobufjs/utf8": "^1.1.0",
     "@types/long": "^4.0.0",
-    "@types/node": "^10.1.0",
+    "@types/node": ">=10.1.0",
     "long": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This change allows dependents to not rely on types for a version of Node that is no longer supported.