### PR TITLE
Allowlist false positive secret detection

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,27 @@
+# This file exists primarily to influence scheduled scans that Apollo runs of all repos in Apollo-managed orgs. 
+# This is an Apollo-Internal link, but more information about these scans is available here:
+# https://apollographql.atlassian.net/wiki/spaces/SecOps/pages/81330213/Everything+Static+Application+Security+Testing#Scheduled-Scans.1
+# 
+# Apollo is using Gitleaks (https://github.com/gitleaks/gitleaks) to run these scans.
+# However, this file is not something that Gitleaks natively consumes. This file is an
+# Apollo-convention. Prior to scanning a repo, Apollo merges
+# our standard Gitleaks configuration (which is largely just the Gitleaks-default config) with
+# this file if it exists in a repo. The combined config is then used to scan a repo.
+# 
+# We did this because the natively-supported allowlisting functionality in Gitleaks didn't do everything we wanted
+# or wasn't as robust as we needed. For example, one of the allowlisting options offered by Gitleaks depends on the line number
+# on which a false positive secret exists to allowlist it. (https://github.com/gitleaks/gitleaks#gitleaksignore).
+# This creates a fairly fragile allowlisting mechanism. This file allows us to leverage the full capabilities of the Gitleaks rule syntax
+# to create allowlisting functionality.
+
+[[ rules ]]
+    id = "generic-api-key"
+    [ rules.allowlist ]
+        commits = [
+            # This creates an allowlist for a CodeClimate API Key
+            # That came from the upstream repo. The Apollo Security
+            # team tested this secret against the CodeClimate API
+            # and was unable to make authenticated requests with it. Key is dead.
+            # See https://github.com/apollographql/protobuf.js/blob/a7ab1036906bb7638193a9e991cb62c86108880a/.travis.yml#L18
+            "a7ab1036906bb7638193a9e991cb62c86108880a",
+        ]


### PR DESCRIPTION
## Context

This adds the `.gitleaks.toml` file in the root of the repo. This file is used to adjust gitleaks configuration when running against this repo. Primarily, this configuration is used to create a repo-local allowlist of detected "secret" values that should be allowed to remain in git history. Usually, this happens if the detected value is not actually a secret or if the detected value was a secret that has since been revoked/rotated. 

## What changed

Added exclusion for detected value that is not secret. 
