### PR TITLE
fix: filter invalid characters from the type name

### DIFF
--- a/src/type.js
+++ b/src/type.js
@@ -29,6 +29,7 @@ var Enum      = require("./enum"),
  * @param {Object.<string,*>} [options] Declared options
  */
 function Type(name, options) {
+    name = name.replace(/\W/g, "");
     Namespace.call(this, name, options);
 
     /**


### PR DESCRIPTION
Sanitize the 'name' parameter by removing non-word characters.

Ported from main protobuf.js commit [535df44](https://github.com/protobufjs/protobuf.js/commit/535df444ac060243722ac5d672db205e5c531d75)

Fixes [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/) (CVE-2026-41242)